### PR TITLE
Add chat message model and chat adapter

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.application")
     id("com.google.gms.google-services")
+    kotlin("android")
 }
 
 android {
@@ -27,6 +28,9 @@ android {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
     }
+    kotlinOptions {
+        jvmTarget = "11"
+    }
 }
 
 dependencies {
@@ -40,4 +44,5 @@ dependencies {
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
     implementation(platform("com.google.firebase:firebase-bom:34.2.0"))
     implementation("com.google.firebase:firebase-analytics")
+    implementation("com.google.firebase:firebase-firestore")
 }

--- a/app/src/main/java/com/example/projectandroid/model/Message.kt
+++ b/app/src/main/java/com/example/projectandroid/model/Message.kt
@@ -1,0 +1,10 @@
+package com.example.projectandroid.model
+
+import com.google.firebase.Timestamp
+
+data class Message(
+    val senderId: String = "",
+    val senderName: String = "",
+    val text: String = "",
+    val createdAt: Timestamp = Timestamp.now()
+)

--- a/app/src/main/java/com/example/projectandroid/ui/ChatAdapter.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/ChatAdapter.kt
@@ -1,0 +1,49 @@
+package com.example.projectandroid.ui
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import com.example.projectandroid.R
+import com.example.projectandroid.model.Message
+
+class ChatAdapter(
+    private val myUid: String,
+    private val items: MutableList<Message>
+) : RecyclerView.Adapter<ChatAdapter.MessageViewHolder>() {
+
+    class MessageViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        val messageText: TextView = view.findViewById(R.id.textMessage)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MessageViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.item_message, parent, false)
+        return MessageViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: MessageViewHolder, position: Int) {
+        val message = items[position]
+        holder.messageText.text = message.text
+        val background = if (message.senderId == myUid) {
+            R.drawable.bg_bubble_me
+        } else {
+            R.drawable.bg_bubble_other
+        }
+        holder.messageText.setBackgroundResource(background)
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    fun submit(newList: List<Message>) {
+        items.clear()
+        items.addAll(newList)
+        notifyDataSetChanged()
+    }
+
+    fun addOne(message: Message) {
+        items.add(message)
+        notifyItemInserted(items.size - 1)
+    }
+}

--- a/app/src/main/res/drawable/bg_bubble_me.xml
+++ b/app/src/main/res/drawable/bg_bubble_me.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="#DCF8C6"/>
+    <corners android:radius="16dp"/>
+</shape>

--- a/app/src/main/res/drawable/bg_bubble_other.xml
+++ b/app/src/main/res/drawable/bg_bubble_other.xml
@@ -1,0 +1,5 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="#FFFFFF"/>
+    <corners android:radius="16dp"/>
+    <stroke android:width="1dp" android:color="#E0E0E0"/>
+</shape>

--- a/app/src/main/res/layout/item_message.xml
+++ b/app/src/main/res/layout/item_message.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="8dp">
+
+    <TextView
+        android:id="@+id/textMessage"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:padding="8dp"
+        android:textColor="@android:color/black"
+        android:background="@drawable/bg_bubble_other" />
+
+</FrameLayout>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,4 +2,5 @@
 plugins {
     id("com.android.application") version "8.8.0-alpha05" apply false
     id("com.google.gms.google-services") version "4.4.3" apply false
+    kotlin("android") version "1.8.22" apply false
 }


### PR DESCRIPTION
## Summary
- add Message data class with sender info, text and Timestamp
- implement ChatAdapter with submit/addOne and sender-based bubbles
- provide message item layout and bubble drawables
- enable Kotlin and Firestore in Gradle config

## Testing
- `gradle test` *(fails: Plugin [id: 'org.jetbrains.kotlin.android', version: '1.8.22'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf89f1659483209cedf6bfa0e9dd64