### PR TITLE
Add chat activity with Firestore message flow

### DIFF
--- a/app/src/main/java/com/example/projectandroid/ui/ChatActivity.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/ChatActivity.kt
@@ -1,0 +1,72 @@
+package com.example.projectandroid.ui
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.View
+import android.widget.EditText
+import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.example.projectandroid.R
+import com.example.projectandroid.model.Message
+import com.google.firebase.auth.ktx.auth
+import com.google.firebase.firestore.FieldValue
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
+
+class ChatActivity : AppCompatActivity() {
+
+    private lateinit var recyclerView: RecyclerView
+    private lateinit var adapter: ChatAdapter
+    private lateinit var messageInput: EditText
+    private lateinit var sendButton: View
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val currentUser = Firebase.auth.currentUser
+        if (currentUser == null) {
+            startActivity(Intent(this, AuthActivity::class.java))
+            finish()
+            return
+        }
+
+        setContentView(R.layout.activity_chat)
+
+        recyclerView = findViewById(R.id.recyclerView)
+        messageInput = findViewById(R.id.editMessage)
+        sendButton = findViewById(R.id.buttonSend)
+
+        adapter = ChatAdapter(currentUser.uid, mutableListOf())
+        recyclerView.layoutManager = LinearLayoutManager(this).apply {
+            stackFromEnd = true
+        }
+        recyclerView.adapter = adapter
+
+        val ref = Firebase.firestore
+            .collection("rooms")
+            .document("general")
+            .collection("messages")
+
+        ref.orderBy("createdAt").addSnapshotListener { value, _ ->
+            val messages = value?.documents?.mapNotNull { it.toObject(Message::class.java) } ?: return@addSnapshotListener
+            adapter.submit(messages)
+            recyclerView.scrollToPosition(adapter.itemCount - 1)
+        }
+
+        sendButton.setOnClickListener {
+            val text = messageInput.text.toString().trim()
+            if (text.isEmpty()) return@setOnClickListener
+
+            val data = mapOf(
+                "senderId" to currentUser.uid,
+                "senderName" to (currentUser.displayName ?: ""),
+                "text" to text,
+                "createdAt" to FieldValue.serverTimestamp()
+            )
+            ref.add(data)
+            messageInput.text.clear()
+        }
+    }
+}
+

--- a/app/src/main/res/layout/activity_chat.xml
+++ b/app/src/main/res/layout/activity_chat.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <EditText
+            android:id="@+id/editMessage"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1" />
+
+        <Button
+            android:id="@+id/buttonSend"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Send" />
+    </LinearLayout>
+
+</LinearLayout>


### PR DESCRIPTION
## Summary
- implement ChatActivity to display and send messages using Firestore
- add chat layout containing RecyclerView, input box, and send button

## Testing
- `gradle test` *(fails: Plugin [id: 'org.jetbrains.kotlin.android', version: '1.8.22'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8b6c089483209c79e96c2677a1c6