### PR TITLE
Set ChatActivity as launcher

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,17 +16,13 @@
         tools:targetApi="31">
 
         <activity
-            android:name=".ui.AuthActivity"
+            android:name=".ui.ChatActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-
-        <activity
-            android:name=".ui.ChatActivity"
-            android:exported="true" />
 
     </application>
 


### PR DESCRIPTION
## Summary
- remove AuthActivity from manifest
- declare ChatActivity as MAIN/LAUNCHER activity

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa3829e608320bd197cd090f3dc27