### PR TITLE
Initialize chat after anonymous auth

### DIFF
--- a/app/src/main/java/com/example/projectandroid/ui/ChatActivity.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/ChatActivity.kt
@@ -1,6 +1,5 @@
 package com.example.projectandroid.ui
 
-import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.widget.EditText
@@ -16,57 +15,62 @@ import com.google.firebase.ktx.Firebase
 
 class ChatActivity : AppCompatActivity() {
 
-    private lateinit var recyclerView: RecyclerView
-    private lateinit var adapter: ChatAdapter
-    private lateinit var messageInput: EditText
-    private lateinit var sendButton: View
+  private lateinit var recyclerView: RecyclerView
+  private lateinit var adapter: ChatAdapter
+  private lateinit var messageInput: EditText
+  private lateinit var sendButton: View
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
 
-        val currentUser = Firebase.auth.currentUser
-        if (currentUser == null) {
-            startActivity(Intent(this, AuthActivity::class.java))
-            finish()
-            return
-        }
-
-        setContentView(R.layout.activity_chat)
-
-        recyclerView = findViewById(R.id.recyclerView)
-        messageInput = findViewById(R.id.editMessage)
-        sendButton = findViewById(R.id.buttonSend)
-
-        adapter = ChatAdapter(currentUser.uid, mutableListOf())
-        recyclerView.layoutManager = LinearLayoutManager(this).apply {
-            stackFromEnd = true
-        }
-        recyclerView.adapter = adapter
-
-        val ref = Firebase.firestore
-            .collection("rooms")
-            .document("general")
-            .collection("messages")
-
-        ref.orderBy("createdAt").addSnapshotListener { value, _ ->
-            val messages = value?.documents?.mapNotNull { it.toObject(Message::class.java) } ?: return@addSnapshotListener
-            adapter.submit(messages)
-            recyclerView.scrollToPosition(adapter.itemCount - 1)
-        }
-
-        sendButton.setOnClickListener {
-            val text = messageInput.text.toString().trim()
-            if (text.isEmpty()) return@setOnClickListener
-
-            val data = mapOf(
-                "senderId" to currentUser.uid,
-                "senderName" to (currentUser.displayName ?: ""),
-                "text" to text,
-                "createdAt" to FieldValue.serverTimestamp()
-            )
-            ref.add(data)
-            messageInput.text.clear()
-        }
+    val auth = Firebase.auth
+    if (auth.currentUser == null) {
+      auth.signInAnonymously().addOnSuccessListener {
+        initChat()
+      }
+    } else {
+      initChat()
     }
-}
+  }
 
+  private fun initChat() {
+    setContentView(R.layout.activity_chat)
+
+    recyclerView = findViewById(R.id.recyclerView)
+    messageInput = findViewById(R.id.editMessage)
+    sendButton = findViewById(R.id.buttonSend)
+
+    val currentUser = Firebase.auth.currentUser!!
+
+    adapter = ChatAdapter(currentUser.uid, mutableListOf())
+    recyclerView.layoutManager = LinearLayoutManager(this).apply {
+      stackFromEnd = true
+    }
+    recyclerView.adapter = adapter
+
+    val ref = Firebase.firestore
+      .collection("rooms")
+      .document("general")
+      .collection("messages")
+
+    ref.orderBy("createdAt").addSnapshotListener { value, _ ->
+      val messages = value?.documents?.mapNotNull { it.toObject(Message::class.java) } ?: return@addSnapshotListener
+      adapter.submit(messages)
+      recyclerView.scrollToPosition(adapter.itemCount - 1)
+    }
+
+    sendButton.setOnClickListener {
+      val text = messageInput.text.toString().trim()
+      if (text.isEmpty()) return@setOnClickListener
+
+      val data = mapOf(
+        "senderId" to currentUser.uid,
+        "senderName" to (currentUser.displayName ?: ""),
+        "text" to text,
+        "createdAt" to FieldValue.serverTimestamp(),
+      )
+      ref.add(data)
+      messageInput.text.clear()
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Sign in anonymously when no Firebase user exists in `ChatActivity`
- Add `initChat()` to set up views and listeners with the authenticated user

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa4353d98832080f18e00dec45f26