### PR TITLE
Handle anonymous sign-in failure in ChatActivity

### DIFF
--- a/app/src/main/java/com/example/projectandroid/ui/ChatActivity.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/ChatActivity.kt
@@ -3,6 +3,7 @@ package com.example.projectandroid.ui
 import android.os.Bundle
 import android.view.View
 import android.widget.EditText
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -25,9 +26,16 @@ class ChatActivity : AppCompatActivity() {
 
     val auth = Firebase.auth
     if (auth.currentUser == null) {
-      auth.signInAnonymously().addOnSuccessListener {
-        initChat()
-      }
+      auth
+        .signInAnonymously()
+        .addOnSuccessListener { initChat() }
+        .addOnFailureListener { e ->
+          Toast.makeText(
+            this,
+            "No se pudo iniciar sesión: ${e.localizedMessage ?: "Revisa tu conexión"}. Inténtalo nuevamente",
+            Toast.LENGTH_LONG,
+          ).show()
+        }
     } else {
       initChat()
     }


### PR DESCRIPTION
## Summary
- add an error callback to anonymous Firebase auth and surface a clear Toast to the user if sign-in fails

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68bfa910a53c8320a19b74bed723d301