### PR TITLE
Refactor ChatAdapter to use ListAdapter

### DIFF
--- a/app/src/main/java/com/example/projectandroid/ui/ChatActivity.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/ChatActivity.kt
@@ -52,7 +52,7 @@ class ChatActivity : AppCompatActivity() {
 
     val currentUser = Firebase.auth.currentUser!!
 
-    adapter = ChatAdapter(currentUser.uid, mutableListOf())
+    adapter = ChatAdapter(currentUser.uid)
     recyclerView.layoutManager = LinearLayoutManager(this).apply {
       stackFromEnd = true
     }
@@ -66,7 +66,7 @@ class ChatActivity : AppCompatActivity() {
     listenerRegistration =
       ref.orderBy("createdAt").addSnapshotListener { value, _ ->
         val messages = value?.documents?.mapNotNull { it.toObject(Message::class.java) } ?: return@addSnapshotListener
-        adapter.submit(messages)
+        adapter.submitList(messages)
         recyclerView.scrollToPosition(adapter.itemCount - 1)
       }
 

--- a/app/src/main/java/com/example/projectandroid/ui/ChatAdapter.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/ChatAdapter.kt
@@ -4,14 +4,15 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.example.projectandroid.R
 import com.example.projectandroid.model.Message
 
 class ChatAdapter(
-    private val myUid: String,
-    private val items: MutableList<Message>
-) : RecyclerView.Adapter<ChatAdapter.MessageViewHolder>() {
+    private val myUid: String
+) : ListAdapter<Message, ChatAdapter.MessageViewHolder>(DIFF_CALLBACK) {
 
     class MessageViewHolder(view: View) : RecyclerView.ViewHolder(view) {
         val messageText: TextView = view.findViewById(R.id.textMessage)
@@ -24,7 +25,7 @@ class ChatAdapter(
     }
 
     override fun onBindViewHolder(holder: MessageViewHolder, position: Int) {
-        val message = items[position]
+        val message = getItem(position)
         holder.messageText.text = message.text
         val background = if (message.senderId == myUid) {
             R.drawable.bg_bubble_me
@@ -34,16 +35,21 @@ class ChatAdapter(
         holder.messageText.setBackgroundResource(background)
     }
 
-    override fun getItemCount(): Int = items.size
-
-    fun submit(newList: List<Message>) {
-        items.clear()
-        items.addAll(newList)
-        notifyDataSetChanged()
+    fun addOne(message: Message) {
+        val newList = currentList.toMutableList()
+        newList.add(message)
+        submitList(newList)
     }
 
-    fun addOne(message: Message) {
-        items.add(message)
-        notifyItemInserted(items.size - 1)
+    companion object {
+        private val DIFF_CALLBACK = object : DiffUtil.ItemCallback<Message>() {
+            override fun areItemsTheSame(oldItem: Message, newItem: Message): Boolean {
+                return oldItem.createdAt == newItem.createdAt
+            }
+
+            override fun areContentsTheSame(oldItem: Message, newItem: Message): Boolean {
+                return oldItem == newItem
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Replace manual RecyclerView.Adapter with ListAdapter and DiffUtil for message list updates
- Update chat activity to use ListAdapter's submitList

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68bfaa4e8f588320a2e920544cd6286a