### PR TITLE
feat: adjust chat layout on keyboard

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,7 +17,8 @@
 
         <activity
             android:name=".ui.ChatActivity"
-            android:exported="true">
+            android:exported="true"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
## Summary
- ensure ChatActivity resizes when keyboard opens

## Testing
- `bash gradlew test` (fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")
- `emulator -version` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68bfaaf38e688320b9607f96ae1f0915