### PR TITLE
feat: log errors for chat activity

### DIFF
--- a/app/src/main/java/com/example/projectandroid/util/ErrorLogger.kt
+++ b/app/src/main/java/com/example/projectandroid/util/ErrorLogger.kt
@@ -1,0 +1,22 @@
+package com.example.projectandroid.util
+
+import android.content.Context
+import android.widget.Toast
+import java.io.File
+import java.util.UUID
+
+object ErrorLogger {
+  fun log(context: Context, throwable: Throwable) {
+    val id = UUID.randomUUID().toString()
+    try {
+      val file = File(context.cacheDir, "error-$id.log")
+      file.printWriter().use { pw ->
+        throwable.printStackTrace(pw)
+      }
+    } catch (_: Exception) {
+      // Ignore logging failures
+    }
+
+    Toast.makeText(context, "Ocurrió un error. ID: $id", Toast.LENGTH_LONG).show()
+  }
+}


### PR DESCRIPTION
## Summary
- log Firestore listener and write errors to cache with ErrorLogger utility
- capture message send failures

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68bfacb791708320bd7c82e7cbd0185b