### PR TITLE
chore: expand app module gitignore

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,1 +1,3 @@
 /build
+*.log
+release/


### PR DESCRIPTION
## Summary
- ensure `app/.gitignore` ends with newline
- ignore log files and release artifacts in app module

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bfae053b9083208f8173ee7c76a1a5