### PR TITLE
Ignore local properties file and document generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 /.gradle/
 /build/
 app/build/
-local.properties
+# Ignore local SDK configuration
+/local.properties
 /.idea/
 *.iml
 *.apk

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # movil
+
+## Configuración local
+
+El archivo `local.properties` contiene la ruta al SDK de Android y no debe añadirse al control de versiones.
+Para generarlo de forma local puedes abrir el proyecto en Android Studio o ejecutar `sdkmanager` desde la línea de comandos.
+En ambos casos se creará un archivo con el contenido similar a:
+
+```
+sdk.dir=/ruta/al/Android/Sdk
+```
+
+Asegúrate de crear este archivo antes de compilar el proyecto.


### PR DESCRIPTION
## Summary
- ignore `local.properties` in version control
- document how to generate `local.properties` locally

## Testing
- `bash ./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68bfae9e35548320bece52256b270784