### PR TITLE
Implement email login and registration

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,8 @@
             </intent-filter>
         </activity>
 
+        <activity android:name=".ui.LoginActivity" android:exported="false" />
+        <activity android:name=".ui.RegisterActivity" android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/projectandroid/ui/ChatActivity.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/ChatActivity.kt
@@ -1,9 +1,9 @@
 package com.example.projectandroid.ui
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.widget.EditText
-import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -29,16 +29,9 @@ class ChatActivity : AppCompatActivity() {
 
     val auth = Firebase.auth
     if (auth.currentUser == null) {
-      auth
-        .signInAnonymously()
-        .addOnSuccessListener { initChat() }
-        .addOnFailureListener { e ->
-          Toast.makeText(
-            this,
-            "No se pudo iniciar sesión: ${e.localizedMessage ?: "Revisa tu conexión"}. Inténtalo nuevamente",
-            Toast.LENGTH_LONG,
-          ).show()
-        }
+      startActivity(Intent(this, LoginActivity::class.java))
+      finish()
+      return
     } else {
       initChat()
     }

--- a/app/src/main/java/com/example/projectandroid/ui/LoginActivity.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/LoginActivity.kt
@@ -1,0 +1,42 @@
+package com.example.projectandroid.ui
+
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Button
+import android.widget.EditText
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import com.example.projectandroid.R
+import com.google.firebase.auth.ktx.auth
+import com.google.firebase.ktx.Firebase
+
+class LoginActivity : AppCompatActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContentView(R.layout.activity_login)
+
+    val emailInput = findViewById<EditText>(R.id.editEmail)
+    val passwordInput = findViewById<EditText>(R.id.editPassword)
+    val loginButton = findViewById<Button>(R.id.buttonLogin)
+    val registerButton = findViewById<Button>(R.id.buttonRegister)
+
+    loginButton.setOnClickListener {
+      val email = emailInput.text.toString().trim()
+      val password = passwordInput.text.toString().trim()
+      if (email.isEmpty() || password.isEmpty()) return@setOnClickListener
+
+      Firebase.auth.signInWithEmailAndPassword(email, password)
+        .addOnSuccessListener {
+          startActivity(Intent(this, ChatActivity::class.java))
+          finish()
+        }
+        .addOnFailureListener { e ->
+          Toast.makeText(this, e.localizedMessage ?: "Error", Toast.LENGTH_LONG).show()
+        }
+    }
+
+    registerButton.setOnClickListener {
+      startActivity(Intent(this, RegisterActivity::class.java))
+    }
+  }
+}

--- a/app/src/main/java/com/example/projectandroid/ui/RegisterActivity.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/RegisterActivity.kt
@@ -1,0 +1,51 @@
+package com.example.projectandroid.ui
+
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Button
+import android.widget.EditText
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import com.example.projectandroid.R
+import com.google.firebase.auth.ktx.auth
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
+
+class RegisterActivity : AppCompatActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContentView(R.layout.activity_register)
+
+    val nameInput = findViewById<EditText>(R.id.editName)
+    val emailInput = findViewById<EditText>(R.id.editEmail)
+    val passwordInput = findViewById<EditText>(R.id.editPassword)
+    val registerButton = findViewById<Button>(R.id.buttonRegister)
+
+    registerButton.setOnClickListener {
+      val name = nameInput.text.toString().trim()
+      val email = emailInput.text.toString().trim()
+      val password = passwordInput.text.toString().trim()
+      if (name.isEmpty() || email.isEmpty() || password.isEmpty()) return@setOnClickListener
+
+      Firebase.auth.createUserWithEmailAndPassword(email, password)
+        .addOnSuccessListener { result ->
+          val uid = result.user?.uid ?: return@addOnSuccessListener
+          val data = mapOf(
+            "name" to name,
+            "uid" to uid,
+          )
+          Firebase.firestore.collection("users").document(uid).set(data)
+            .addOnSuccessListener {
+              startActivity(Intent(this, ChatActivity::class.java))
+              finish()
+            }
+            .addOnFailureListener { e ->
+              Toast.makeText(this, e.localizedMessage ?: "Error", Toast.LENGTH_LONG).show()
+            }
+        }
+        .addOnFailureListener { e ->
+          Toast.makeText(this, e.localizedMessage ?: "Error", Toast.LENGTH_LONG).show()
+        }
+    }
+  }
+}

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <EditText
+        android:id="@+id/editEmail"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Email"
+        android:inputType="textEmailAddress" />
+
+    <EditText
+        android:id="@+id/editPassword"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Password"
+        android:inputType="textPassword" />
+
+    <Button
+        android:id="@+id/buttonLogin"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Login" />
+
+    <Button
+        android:id="@+id/buttonRegister"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Register" />
+</LinearLayout>

--- a/app/src/main/res/layout/activity_register.xml
+++ b/app/src/main/res/layout/activity_register.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <EditText
+        android:id="@+id/editName"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Name" />
+
+    <EditText
+        android:id="@+id/editEmail"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Email"
+        android:inputType="textEmailAddress" />
+
+    <EditText
+        android:id="@+id/editPassword"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Password"
+        android:inputType="textPassword" />
+
+    <Button
+        android:id="@+id/buttonRegister"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Register" />
+</LinearLayout>


### PR DESCRIPTION
## Summary
- add LoginActivity and RegisterActivity for Firebase email/password auth
- store new user name and UID in Firestore
- redirect unauthenticated users to LoginActivity

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68c0559da14c832099c61ef5a1379ad9