### PR TITLE
Define User model and repository for Firestore

### DIFF
--- a/app/src/main/java/com/example/projectandroid/model/User.kt
+++ b/app/src/main/java/com/example/projectandroid/model/User.kt
@@ -1,0 +1,10 @@
+package com.example.projectandroid.model
+
+/**
+ * Represents a user profile stored in Firestore.
+ */
+data class User(
+    val uid: String = "",
+    val displayName: String = "",
+    val photoUrl: String? = null,
+)

--- a/app/src/main/java/com/example/projectandroid/repository/UserRepository.kt
+++ b/app/src/main/java/com/example/projectandroid/repository/UserRepository.kt
@@ -1,0 +1,21 @@
+package com.example.projectandroid.repository
+
+import com.example.projectandroid.model.User
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
+
+class UserRepository {
+    private val usersCollection = Firebase.firestore.collection("users")
+
+    fun getUsersByDisplayName(displayName: String, onSuccess: (List<User>) -> Unit, onFailure: (Exception) -> Unit) {
+        usersCollection.whereEqualTo("displayName", displayName)
+            .get()
+            .addOnSuccessListener { result ->
+                val users = result.documents.mapNotNull { it.toObject(User::class.java) }
+                onSuccess(users)
+            }
+            .addOnFailureListener { exception ->
+                onFailure(exception)
+            }
+    }
+}

--- a/app/src/main/java/com/example/projectandroid/ui/RegisterActivity.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/RegisterActivity.kt
@@ -7,7 +7,9 @@ import android.widget.EditText
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.example.projectandroid.R
+import com.example.projectandroid.model.User
 import com.google.firebase.auth.ktx.auth
+import com.google.firebase.auth.ktx.userProfileChangeRequest
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 
@@ -29,12 +31,18 @@ class RegisterActivity : AppCompatActivity() {
 
       Firebase.auth.createUserWithEmailAndPassword(email, password)
         .addOnSuccessListener { result ->
-          val uid = result.user?.uid ?: return@addOnSuccessListener
-          val data = mapOf(
-            "name" to name,
-            "uid" to uid,
+          val user = result.user ?: return@addOnSuccessListener
+          // Update the FirebaseAuth profile with the provided display name
+          val profileUpdates = userProfileChangeRequest { displayName = name }
+          user.updateProfile(profileUpdates)
+
+          val profile = User(
+            uid = user.uid,
+            displayName = name,
+            photoUrl = user.photoUrl?.toString(),
           )
-          Firebase.firestore.collection("users").document(uid).set(data)
+
+          Firebase.firestore.collection("users").document(user.uid).set(profile)
             .addOnSuccessListener {
               startActivity(Intent(this, ChatActivity::class.java))
               finish()


### PR DESCRIPTION
## Summary
- add `User` model representing profile data
- save user profile to Firestore on registration
- implement `UserRepository` to query users by `displayName`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c057419e2c832086179aefd7064ea1