### PR TITLE
Display contact name in chat screen

### DIFF
--- a/app/src/main/java/com/example/projectandroid/ui/ChatActivity.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/ChatActivity.kt
@@ -36,16 +36,19 @@ class ChatActivity : AppCompatActivity() {
     }
 
     val recipientUid = intent.getStringExtra("recipientUid")
-    if (recipientUid.isNullOrBlank()) {
+    val recipientName = intent.getStringExtra("recipientName")
+    if (recipientUid.isNullOrBlank() || recipientName.isNullOrBlank()) {
       finish()
       return
     }
 
-    initChat(currentUser.uid, recipientUid)
+    initChat(currentUser.uid, recipientUid, recipientName)
   }
 
-  private fun initChat(currentUid: String, recipientUid: String) {
+  private fun initChat(currentUid: String, recipientUid: String, recipientName: String) {
     setContentView(R.layout.activity_chat)
+
+    supportActionBar?.title = recipientName
 
     recyclerView = findViewById(R.id.recyclerView)
     messageInput = findViewById(R.id.editMessage)

--- a/app/src/main/java/com/example/projectandroid/ui/SearchUserActivity.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/SearchUserActivity.kt
@@ -28,8 +28,10 @@ class SearchUserActivity : AppCompatActivity() {
         setContentView(R.layout.activity_search_user)
 
         adapter = UserAdapter { user ->
-            val intent = Intent(this, ChatActivity::class.java)
-            intent.putExtra("recipientUid", user.uid)
+            val intent = Intent(this, ChatActivity::class.java).apply {
+                putExtra("recipientUid", user.uid)
+                putExtra("recipientName", user.displayName)
+            }
             startActivity(intent)
         }
 


### PR DESCRIPTION
## Summary
- Pass both UID and display name to chat activity via Intent
- Set chat screen title to the selected contact's name
- Ensure messages load from private room derived from both users' UIDs

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c0596bd9088320b21c7b1842fe1023