### PR TITLE
Validate credentials and log auth errors

### DIFF
--- a/app/src/main/java/com/example/projectandroid/ui/LoginActivity.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/LoginActivity.kt
@@ -4,9 +4,11 @@ import android.content.Intent
 import android.os.Bundle
 import android.widget.Button
 import android.widget.EditText
+import android.util.Patterns
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.example.projectandroid.R
+import com.example.projectandroid.util.ErrorLogger
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
 
@@ -23,7 +25,17 @@ class LoginActivity : AppCompatActivity() {
     loginButton.setOnClickListener {
       val email = emailInput.text.toString().trim()
       val password = passwordInput.text.toString().trim()
-      if (email.isEmpty() || password.isEmpty()) return@setOnClickListener
+
+      var isValid = true
+      if (!Patterns.EMAIL_ADDRESS.matcher(email).matches()) {
+        emailInput.error = getString(R.string.invalid_email)
+        isValid = false
+      }
+      if (password.length < 6) {
+        passwordInput.error = getString(R.string.invalid_password)
+        isValid = false
+      }
+      if (!isValid) return@setOnClickListener
 
       Firebase.auth.signInWithEmailAndPassword(email, password)
         .addOnSuccessListener {
@@ -31,7 +43,8 @@ class LoginActivity : AppCompatActivity() {
           finish()
         }
         .addOnFailureListener { e ->
-          Toast.makeText(this, e.localizedMessage ?: "Error", Toast.LENGTH_LONG).show()
+          ErrorLogger.log(this, e)
+          Toast.makeText(this, e.localizedMessage ?: getString(R.string.error_generic), Toast.LENGTH_LONG).show()
         }
     }
 

--- a/app/src/main/java/com/example/projectandroid/ui/SearchUserActivity.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/SearchUserActivity.kt
@@ -8,6 +8,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.projectandroid.R
 import com.example.projectandroid.repository.UserRepository
+import com.example.projectandroid.util.ErrorLogger
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
 
@@ -49,7 +50,9 @@ class SearchUserActivity : AppCompatActivity() {
                 } else {
                     userRepository.getUsersByDisplayName(q, onSuccess = { users ->
                         adapter.submitList(users)
-                    }, onFailure = {})
+                    }, onFailure = { e ->
+                        ErrorLogger.log(this@SearchUserActivity, e)
+                    })
                 }
                 return true
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,7 @@
 <resources>
     <string name="app_name">projectAndroid</string>
+    <string name="invalid_email">Email inválido</string>
+    <string name="invalid_password">La contraseña debe tener al menos 6 caracteres</string>
+    <string name="error_generic">Error</string>
+    <string name="required_field">Campo requerido</string>
 </resources>


### PR DESCRIPTION
## Summary
- validate email format and password length before Firebase auth calls
- display auth failures and log network issues via `ErrorLogger`
- add shared string resources for validation errors

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c05a7609b48320bec5682c215050c6