### PR TITLE
Add chat list activity with Firestore rooms and search

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,10 @@
             android:windowSoftInputMode="adjustResize" />
 
         <activity
+            android:name=".ui.ChatListActivity"
+            android:exported="false" />
+
+        <activity
             android:name=".ui.SearchUserActivity"
             android:exported="true">
             <intent-filter>

--- a/app/src/main/java/com/example/projectandroid/model/ChatRoom.kt
+++ b/app/src/main/java/com/example/projectandroid/model/ChatRoom.kt
@@ -1,0 +1,14 @@
+package com.example.projectandroid.model
+
+import com.google.firebase.Timestamp
+
+/**
+ * Represents a chat room with summary info for the list.
+ */
+data class ChatRoom(
+    val id: String = "",
+    val contactUid: String = "",
+    val contactName: String = "",
+    val lastMessage: String = "",
+    val updatedAt: Timestamp = Timestamp.now(),
+)

--- a/app/src/main/java/com/example/projectandroid/ui/ChatListActivity.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/ChatListActivity.kt
@@ -1,0 +1,102 @@
+package com.example.projectandroid.ui
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.SearchView
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.example.projectandroid.R
+import com.example.projectandroid.model.ChatRoom
+import com.example.projectandroid.util.ErrorLogger
+import com.google.firebase.auth.ktx.auth
+import com.google.firebase.firestore.ListenerRegistration
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
+import java.util.Locale
+
+class ChatListActivity : AppCompatActivity() {
+    private lateinit var adapter: ChatListAdapter
+    private lateinit var searchView: SearchView
+    private var allRooms: List<ChatRoom> = emptyList()
+    private lateinit var listenerRegistration: ListenerRegistration
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val auth = Firebase.auth
+        val currentUser = auth.currentUser
+        if (currentUser == null) {
+            startActivity(Intent(this, LoginActivity::class.java))
+            finish()
+            return
+        }
+
+        setContentView(R.layout.activity_chat_list)
+
+        adapter = ChatListAdapter { room ->
+            val intent = Intent(this, ChatActivity::class.java).apply {
+                putExtra("recipientUid", room.contactUid)
+                putExtra("recipientName", room.contactName)
+            }
+            startActivity(intent)
+        }
+
+        val recycler = findViewById<RecyclerView>(R.id.recyclerChats)
+        recycler.layoutManager = LinearLayoutManager(this)
+        recycler.adapter = adapter
+
+        searchView = findViewById(R.id.searchView)
+        searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
+            override fun onQueryTextSubmit(query: String?): Boolean = false
+            override fun onQueryTextChange(newText: String?): Boolean {
+                filterRooms(newText ?: "")
+                return true
+            }
+        })
+
+        listenerRegistration = Firebase.firestore
+            .collection("rooms")
+            .whereArrayContains("participantIds", currentUser.uid)
+            .addSnapshotListener { value, error ->
+                if (error != null) {
+                    ErrorLogger.log(this, error)
+                    return@addSnapshotListener
+                }
+                val list = value?.documents?.mapNotNull { doc ->
+                    val participantIds = doc.get("participantIds") as? List<*>
+                    val otherUid = participantIds?.firstOrNull { it != currentUser.uid } as? String
+                    val userNames = doc.get("userNames") as? Map<*, *>
+                    val contactName = userNames?.get(otherUid) as? String ?: ""
+                    val lastMessage = doc.getString("lastMessage") ?: ""
+                    val updatedAt = doc.getTimestamp("updatedAt")
+                        ?: com.google.firebase.Timestamp.now()
+                    if (otherUid == null) null else ChatRoom(
+                        id = doc.id,
+                        contactUid = otherUid,
+                        contactName = contactName,
+                        lastMessage = lastMessage,
+                        updatedAt = updatedAt,
+                    )
+                } ?: emptyList()
+                allRooms = list
+                filterRooms(searchView.query.toString())
+            }
+    }
+
+    private fun filterRooms(query: String) {
+        if (query.isBlank()) {
+            adapter.submitList(allRooms)
+        } else {
+            val lower = query.lowercase(Locale.getDefault())
+            adapter.submitList(allRooms.filter { it.contactName.lowercase(Locale.getDefault()).contains(lower) })
+        }
+    }
+
+    override fun onDestroy() {
+        if (::listenerRegistration.isInitialized) {
+            listenerRegistration.remove()
+        }
+        super.onDestroy()
+    }
+}

--- a/app/src/main/java/com/example/projectandroid/ui/ChatListAdapter.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/ChatListAdapter.kt
@@ -1,0 +1,51 @@
+package com.example.projectandroid.ui
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.example.projectandroid.R
+import com.example.projectandroid.model.ChatRoom
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+class ChatListAdapter(
+    private val onClick: (ChatRoom) -> Unit,
+) : ListAdapter<ChatRoom, ChatListAdapter.ChatRoomViewHolder>(DIFF_CALLBACK) {
+
+    class ChatRoomViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        val nameText: TextView = view.findViewById(R.id.textName)
+        val lastMessageText: TextView = view.findViewById(R.id.textLastMessage)
+        val timeText: TextView = view.findViewById(R.id.textTime)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ChatRoomViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.item_chat_room, parent, false)
+        return ChatRoomViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: ChatRoomViewHolder, position: Int) {
+        val room = getItem(position)
+        holder.nameText.text = room.contactName
+        holder.lastMessageText.text = room.lastMessage
+        val timeFormat = SimpleDateFormat("HH:mm", Locale.getDefault())
+        holder.timeText.text = timeFormat.format(room.updatedAt.toDate())
+        holder.itemView.setOnClickListener { onClick(room) }
+    }
+
+    companion object {
+        private val DIFF_CALLBACK = object : DiffUtil.ItemCallback<ChatRoom>() {
+            override fun areItemsTheSame(oldItem: ChatRoom, newItem: ChatRoom): Boolean {
+                return oldItem.id == newItem.id
+            }
+
+            override fun areContentsTheSame(oldItem: ChatRoom, newItem: ChatRoom): Boolean {
+                return oldItem == newItem
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_chat_list.xml
+++ b/app/src/main/res/layout/activity_chat_list.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <androidx.appcompat.widget.SearchView
+        android:id="@+id/searchView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerChats"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+</LinearLayout>

--- a/app/src/main/res/layout/item_chat_room.xml
+++ b/app/src/main/res/layout/item_chat_room.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/textName"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="16sp"
+        android:textStyle="bold" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/textLastMessage"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:ellipsize="end"
+            android:maxLines="1" />
+
+        <TextView
+            android:id="@+id/textTime"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingStart="8dp" />
+    </LinearLayout>
+</LinearLayout>


### PR DESCRIPTION
## Summary
- add ChatRoom model
- implement ChatListAdapter to show room name, last message and time
- introduce ChatListActivity with Firestore rooms and search filtering
- include layouts and manifest entry

## Testing
- `./gradlew test` *(failed: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c05ccf06e883208087da2f13f79c32