### PR TITLE
Start with chat list after login

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,16 +22,16 @@
 
         <activity
             android:name=".ui.ChatListActivity"
-            android:exported="false" />
-
-        <activity
-            android:name=".ui.SearchUserActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <activity
+            android:name=".ui.SearchUserActivity"
+            android:exported="false" />
 
         <activity android:name=".ui.LoginActivity" android:exported="false" />
         <activity android:name=".ui.RegisterActivity" android:exported="false" />

--- a/app/src/main/java/com/example/projectandroid/ui/LoginActivity.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/LoginActivity.kt
@@ -39,7 +39,7 @@ class LoginActivity : AppCompatActivity() {
 
       Firebase.auth.signInWithEmailAndPassword(email, password)
         .addOnSuccessListener {
-          startActivity(Intent(this, SearchUserActivity::class.java))
+          startActivity(Intent(this, ChatListActivity::class.java))
           finish()
         }
         .addOnFailureListener { e ->


### PR DESCRIPTION
## Summary
- Redirect users to chat list after successful login
- Make ChatListActivity the launcher and keep SearchUserActivity internal

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c0613d269c832097f06b9cb83a9129