### PR TITLE
Add logout option in chat list

### DIFF
--- a/app/src/main/java/com/example/projectandroid/ui/ChatListActivity.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/ChatListActivity.kt
@@ -2,6 +2,8 @@ package com.example.projectandroid.ui
 
 import android.content.Intent
 import android.os.Bundle
+import android.view.Menu
+import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.SearchView
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -9,10 +11,12 @@ import androidx.recyclerview.widget.RecyclerView
 import com.example.projectandroid.R
 import com.example.projectandroid.model.ChatRoom
 import com.example.projectandroid.util.ErrorLogger
+import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.firestore.ListenerRegistration
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
+import com.google.android.material.appbar.MaterialToolbar
 import java.util.Locale
 
 class ChatListActivity : AppCompatActivity() {
@@ -33,6 +37,8 @@ class ChatListActivity : AppCompatActivity() {
         }
 
         setContentView(R.layout.activity_chat_list)
+        val toolbar = findViewById<MaterialToolbar>(R.id.topAppBar)
+        setSupportActionBar(toolbar)
 
         adapter = ChatListAdapter { room ->
             val intent = Intent(this, ChatActivity::class.java).apply {
@@ -82,6 +88,25 @@ class ChatListActivity : AppCompatActivity() {
                 allRooms = list
                 filterRooms(searchView.query.toString())
             }
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        menuInflater.inflate(R.menu.menu_chat_list, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.action_logout -> {
+                FirebaseAuth.getInstance().signOut()
+                val intent = Intent(this, LoginActivity::class.java)
+                intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                startActivity(intent)
+                finish()
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
     }
 
     private fun filterRooms(query: String) {

--- a/app/src/main/res/layout/activity_chat_list.xml
+++ b/app/src/main/res/layout/activity_chat_list.xml
@@ -4,6 +4,13 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/topAppBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorPrimary"
+        android:theme="@style/ThemeOverlay.Material3.Dark.ActionBar" />
+
     <androidx.appcompat.widget.SearchView
         android:id="@+id/searchView"
         android:layout_width="match_parent"

--- a/app/src/main/res/menu/menu_chat_list.xml
+++ b/app/src/main/res/menu/menu_chat_list.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/action_logout"
+        android:title="@string/logout"
+        android:icon="@android:drawable/ic_lock_power_off"
+        app:showAsAction="ifRoom" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,4 +4,5 @@
     <string name="invalid_password">La contraseña debe tener al menos 6 caracteres</string>
     <string name="error_generic">Error</string>
     <string name="required_field">Campo requerido</string>
+    <string name="logout">Cerrar sesión</string>
 </resources>


### PR DESCRIPTION
## Summary
- Add app bar with logout menu icon on chat list
- Handle logout by clearing activity stack and redirecting to login

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c06275682483208783bbe23091533d