### PR TITLE
feat: apply material design components

### DIFF
--- a/app/src/main/java/com/example/projectandroid/ui/ChatActivity.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/ChatActivity.kt
@@ -2,12 +2,12 @@ package com.example.projectandroid.ui
 
 import android.content.Intent
 import android.os.Bundle
-import android.view.View
-import android.widget.EditText
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.appbar.MaterialToolbar
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.textfield.TextInputEditText
 import com.example.projectandroid.R
 import com.example.projectandroid.model.Message
 import com.google.firebase.auth.ktx.auth
@@ -21,8 +21,8 @@ class ChatActivity : AppCompatActivity() {
 
   private lateinit var recyclerView: RecyclerView
   private lateinit var adapter: ChatAdapter
-  private lateinit var messageInput: EditText
-  private lateinit var sendButton: View
+  private lateinit var messageInput: TextInputEditText
+  private lateinit var sendButton: MaterialButton
   private lateinit var listenerRegistration: ListenerRegistration
 
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -92,7 +92,7 @@ class ChatActivity : AppCompatActivity() {
         "createdAt" to FieldValue.serverTimestamp(),
       )
       ref.add(data).addOnFailureListener { e -> ErrorLogger.log(this, e) }
-      messageInput.text.clear()
+      messageInput.text?.clear()
     }
   }
 

--- a/app/src/main/java/com/example/projectandroid/ui/LoginActivity.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/LoginActivity.kt
@@ -2,13 +2,13 @@ package com.example.projectandroid.ui
 
 import android.content.Intent
 import android.os.Bundle
-import android.widget.Button
-import android.widget.EditText
 import android.util.Patterns
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.example.projectandroid.R
 import com.example.projectandroid.util.ErrorLogger
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.textfield.TextInputEditText
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
 
@@ -17,10 +17,10 @@ class LoginActivity : AppCompatActivity() {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_login)
 
-    val emailInput = findViewById<EditText>(R.id.editEmail)
-    val passwordInput = findViewById<EditText>(R.id.editPassword)
-    val loginButton = findViewById<Button>(R.id.buttonLogin)
-    val registerButton = findViewById<Button>(R.id.buttonRegister)
+    val emailInput = findViewById<TextInputEditText>(R.id.editEmail)
+    val passwordInput = findViewById<TextInputEditText>(R.id.editPassword)
+    val loginButton = findViewById<MaterialButton>(R.id.buttonLogin)
+    val registerButton = findViewById<MaterialButton>(R.id.buttonRegister)
 
     loginButton.setOnClickListener {
       val email = emailInput.text.toString().trim()

--- a/app/src/main/java/com/example/projectandroid/ui/RegisterActivity.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/RegisterActivity.kt
@@ -2,14 +2,14 @@ package com.example.projectandroid.ui
 
 import android.content.Intent
 import android.os.Bundle
-import android.widget.Button
-import android.widget.EditText
 import android.util.Patterns
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.example.projectandroid.R
 import com.example.projectandroid.model.User
 import com.example.projectandroid.util.ErrorLogger
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.textfield.TextInputEditText
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.auth.ktx.userProfileChangeRequest
 import com.google.firebase.firestore.ktx.firestore
@@ -20,10 +20,10 @@ class RegisterActivity : AppCompatActivity() {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_register)
 
-    val nameInput = findViewById<EditText>(R.id.editName)
-    val emailInput = findViewById<EditText>(R.id.editEmail)
-    val passwordInput = findViewById<EditText>(R.id.editPassword)
-    val registerButton = findViewById<Button>(R.id.buttonRegister)
+    val nameInput = findViewById<TextInputEditText>(R.id.editName)
+    val emailInput = findViewById<TextInputEditText>(R.id.editEmail)
+    val passwordInput = findViewById<TextInputEditText>(R.id.editPassword)
+    val registerButton = findViewById<MaterialButton>(R.id.buttonRegister)
 
     registerButton.setOnClickListener {
       val name = nameInput.text.toString().trim()

--- a/app/src/main/res/drawable/ic_email.xml
+++ b/app/src/main/res/drawable/ic_email.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/black"
+        android:pathData="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.89 2 1.99 2H20c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_lock.xml
+++ b/app/src/main/res/drawable/ic_lock.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/black"
+        android:pathData="M12 17c1.1 0 2-.9 2-2v-2c0-1.1-.9-2-2-2s-2 .9-2 2v2c0 1.1.9 2 2 2zm6-6h-1V9c0-2.76-2.24-5-5-5S7 6.24 7 9v2H6c-1.1 0-2 .9-2 2v8c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-8c0-1.1-.9-2-2-2zm-6-6c1.66 0 3 1.34 3 3v2H9V9c0-1.66 1.34-3 3-3z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_logout.xml
+++ b/app/src/main/res/drawable/ic_logout.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/black"
+        android:pathData="M17,7l-1.41,1.41L18.17,11H8v2h10.17l-2.58,2.59L17,17l5,-5zM4,5h7V3H4c-1.1,0-2,0.9-2,2v14c0,1.1,0.9,2,2,2h7v-2H4V5z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_person.xml
+++ b/app/src/main/res/drawable/ic_person.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/black"
+        android:pathData="M12 12c2.7 0 5-2.3 5-5s-2.3-5-5-5-5 2.3-5 5 2.3 5 5 5zm0 2c-3.3 0-10 1.7-10 5v3h20v-3c0-3.3-6.7-5-10-5z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_send.xml
+++ b/app/src/main/res/drawable/ic_send.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/black"
+        android:pathData="M2,21L23,12L2,3V10L17,12L2,14V21Z"/>
+</vector>

--- a/app/src/main/res/layout/activity_chat.xml
+++ b/app/src/main/res/layout/activity_chat.xml
@@ -21,20 +21,29 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal">
+        android:orientation="horizontal"
+        android:padding="8dp">
 
-        <EditText
-            android:id="@+id/editMessage"
+        <com.google.android.material.textfield.TextInputLayout
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:hint="Escribe un mensaje" />
+            android:hint="Escribe un mensaje">
 
-        <Button
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/editMessage"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/buttonSend"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Enviar" />
+            android:text="Enviar"
+            app:icon="@drawable/ic_send"
+            app:iconGravity="textStart"
+            app:iconPadding="0dp" />
     </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -1,31 +1,44 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
     android:padding="16dp">
 
-    <EditText
-        android:id="@+id/editEmail"
+    <com.google.android.material.textfield.TextInputLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:hint="Email"
-        android:inputType="textEmailAddress" />
+        app:startIconDrawable="@drawable/ic_email">
 
-    <EditText
-        android:id="@+id/editPassword"
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/editEmail"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="textEmailAddress" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:hint="Password"
-        android:inputType="textPassword" />
+        app:startIconDrawable="@drawable/ic_lock">
 
-    <Button
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/editPassword"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="textPassword" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/buttonLogin"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Login" />
 
-    <Button
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/buttonRegister"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_register.xml
+++ b/app/src/main/res/layout/activity_register.xml
@@ -1,31 +1,50 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
     android:padding="16dp">
 
-    <EditText
-        android:id="@+id/editName"
+    <com.google.android.material.textfield.TextInputLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="Name" />
+        android:hint="Name"
+        app:startIconDrawable="@drawable/ic_person">
 
-    <EditText
-        android:id="@+id/editEmail"
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/editName"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:hint="Email"
-        android:inputType="textEmailAddress" />
+        app:startIconDrawable="@drawable/ic_email">
 
-    <EditText
-        android:id="@+id/editPassword"
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/editEmail"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="textEmailAddress" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:hint="Password"
-        android:inputType="textPassword" />
+        app:startIconDrawable="@drawable/ic_lock">
 
-    <Button
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/editPassword"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="textPassword" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/buttonRegister"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/app/src/main/res/menu/menu_chat_list.xml
+++ b/app/src/main/res/menu/menu_chat_list.xml
@@ -4,6 +4,6 @@
     <item
         android:id="@+id/action_logout"
         android:title="@string/logout"
-        android:icon="@android:drawable/ic_lock_power_off"
+        android:icon="@drawable/ic_logout"
         app:showAsAction="ifRoom" />
 </menu>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <color name="md_theme_light_primary">#6750A4</color>
+    <color name="md_theme_light_onPrimary">#FFFFFF</color>
+    <color name="md_theme_light_primaryContainer">#EADDFF</color>
+    <color name="md_theme_light_onPrimaryContainer">#21005D</color>
+    <color name="md_theme_light_secondary">#625B71</color>
+    <color name="md_theme_light_onSecondary">#FFFFFF</color>
+    <color name="md_theme_light_secondaryContainer">#E8DEF8</color>
+    <color name="md_theme_light_onSecondaryContainer">#1D192B</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,8 +1,14 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
     <style name="Base.Theme.ProjectAndroid" parent="Theme.Material3.DayNight.NoActionBar">
-        <!-- Customize your light theme here. -->
-        <!-- <item name="colorPrimary">@color/my_light_primary</item> -->
+        <item name="colorPrimary">@color/md_theme_light_primary</item>
+        <item name="colorOnPrimary">@color/md_theme_light_onPrimary</item>
+        <item name="colorPrimaryContainer">@color/md_theme_light_primaryContainer</item>
+        <item name="colorOnPrimaryContainer">@color/md_theme_light_onPrimaryContainer</item>
+        <item name="colorSecondary">@color/md_theme_light_secondary</item>
+        <item name="colorOnSecondary">@color/md_theme_light_onSecondary</item>
+        <item name="colorSecondaryContainer">@color/md_theme_light_secondaryContainer</item>
+        <item name="colorOnSecondaryContainer">@color/md_theme_light_onSecondaryContainer</item>
     </style>
 
     <style name="Theme.ProjectAndroid" parent="Base.Theme.ProjectAndroid"/>


### PR DESCRIPTION
## Summary
- replace classic widgets in login, register and chat screens with Material components
- define Material3 theme with custom colors
- add vector icons including logout action in chat list AppBar

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f28b71648320b446c8f05947a471