### PR TITLE
Show progress during login and improve error handling

### DIFF
--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -43,4 +43,11 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="Register" />
+
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:visibility="gone" />
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,4 +6,7 @@
     <string name="required_field">Campo requerido</string>
     <string name="logout">Cerrar sesión</string>
     <string name="chats_title">Chats</string>
+    <string name="error_invalid_user">Usuario no registrado</string>
+    <string name="error_invalid_credentials">Credenciales incorrectas</string>
+    <string name="error_network">Error de red</string>
 </resources>


### PR DESCRIPTION
## Summary
- Show a progress bar and disable the login button during authentication
- Display specific Firebase authentication errors via Toast
- Add string resources and layout for progress feedback

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c0f4ac11948320b8edd580e15d46cf