### PR TITLE
Show loading indicator for chat list and persist Firestore query

### DIFF
--- a/app/src/main/java/com/example/projectandroid/ui/ChatListViewModel.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/ChatListViewModel.kt
@@ -1,0 +1,61 @@
+package com.example.projectandroid.ui
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.example.projectandroid.model.ChatRoom
+import com.google.firebase.firestore.ListenerRegistration
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
+
+class ChatListViewModel : ViewModel() {
+
+    private val _rooms = MutableLiveData<List<ChatRoom>>()
+    val rooms: LiveData<List<ChatRoom>> = _rooms
+
+    private val _loading = MutableLiveData<Boolean>()
+    val loading: LiveData<Boolean> = _loading
+
+    private val _error = MutableLiveData<Exception?>()
+    val error: LiveData<Exception?> = _error
+
+    private var listenerRegistration: ListenerRegistration? = null
+
+    fun startListening(currentUserUid: String) {
+        if (listenerRegistration != null) return
+        _loading.value = true
+        listenerRegistration = Firebase.firestore
+            .collection("rooms")
+            .whereArrayContains("participantIds", currentUserUid)
+            .addSnapshotListener { value, e ->
+                _loading.value = false
+                if (e != null) {
+                    _error.value = e
+                    return@addSnapshotListener
+                }
+                val list = value?.documents?.mapNotNull { doc ->
+                    val participantIds = doc.get("participantIds") as? List<*>
+                    val otherUid = participantIds?.firstOrNull { it != currentUserUid } as? String
+                    val userNames = doc.get("userNames") as? Map<*, *>
+                    val contactName = userNames?.get(otherUid) as? String ?: ""
+                    val lastMessage = doc.getString("lastMessage") ?: ""
+                    val updatedAt = doc.getTimestamp("updatedAt")
+                        ?: com.google.firebase.Timestamp.now()
+                    if (otherUid == null) null else ChatRoom(
+                        id = doc.id,
+                        contactUid = otherUid,
+                        contactName = contactName,
+                        lastMessage = lastMessage,
+                        updatedAt = updatedAt,
+                    )
+                } ?: emptyList()
+                _rooms.value = list
+            }
+    }
+
+    override fun onCleared() {
+        listenerRegistration?.remove()
+        super.onCleared()
+    }
+}
+

--- a/app/src/main/res/layout/activity_chat_list.xml
+++ b/app/src/main/res/layout/activity_chat_list.xml
@@ -18,9 +18,30 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/recyclerChats"
+    <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1" />
+        android:layout_weight="1">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerChats"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+        <TextView
+            android:id="@+id/textPlaceholder"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:text="@string/no_chats_placeholder"
+            android:visibility="gone" />
+
+        <ProgressBar
+            android:id="@+id/progressBar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:visibility="gone" />
+
+    </FrameLayout>
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,4 +9,5 @@
     <string name="error_invalid_user">Usuario no registrado</string>
     <string name="error_invalid_credentials">Credenciales incorrectas</string>
     <string name="error_network">Error de red</string>
+    <string name="no_chats_placeholder">No tienes chats aún</string>
 </resources>


### PR DESCRIPTION
## Summary
- add progress bar and empty placeholder to chat list UI
- move Firestore rooms query into ViewModel to survive configuration changes

## Testing
- `./gradlew test` (fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68c0f5a501dc832099d9e7a767f1baf2