### PR TITLE
Add log sharing capability

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,6 +35,16 @@
 
         <activity android:name=".ui.LoginActivity" android:exported="false" />
         <activity android:name=".ui.RegisterActivity" android:exported="false" />
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/projectandroid/ui/ChatListActivity.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/ChatListActivity.kt
@@ -103,6 +103,10 @@ class ChatListActivity : AppCompatActivity() {
                 finish()
                 true
             }
+            R.id.action_share_logs -> {
+                AppLogger.shareLogs(this)
+                true
+            }
             else -> super.onOptionsItemSelected(item)
         }
     }

--- a/app/src/main/res/menu/menu_chat_list.xml
+++ b/app/src/main/res/menu/menu_chat_list.xml
@@ -6,4 +6,9 @@
         android:title="@string/logout"
         android:icon="@drawable/ic_logout"
         app:showAsAction="ifRoom" />
+    <item
+        android:id="@+id/action_share_logs"
+        android:title="@string/share_logs"
+        android:icon="@android:drawable/ic_menu_share"
+        app:showAsAction="ifRoom" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,4 +10,5 @@
     <string name="error_invalid_credentials">Credenciales incorrectas</string>
     <string name="error_network">Error de red</string>
     <string name="no_chats_placeholder">No tienes chats aún</string>
+    <string name="share_logs">Compartir logs</string>
 </resources>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <files-path name="logs" path="logs/" />
+</paths>


### PR DESCRIPTION
## Summary
- enable sharing of log files via new `AppLogger.shareLogs`
- configure FileProvider and add menu action to trigger log sharing

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy: HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c10b32a56483208d42de6617eedb69