### PR TITLE
Log uncaught exceptions at application level

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+        android:name=".ProjectApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/example/projectandroid/ProjectApplication.kt
+++ b/app/src/main/java/com/example/projectandroid/ProjectApplication.kt
@@ -1,0 +1,16 @@
+package com.example.projectandroid
+
+import android.app.Application
+import com.example.projectandroid.util.AppLogger
+
+class ProjectApplication : Application() {
+  override fun onCreate() {
+    super.onCreate()
+
+    val defaultHandler = Thread.getDefaultUncaughtExceptionHandler()
+    Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
+      AppLogger.logError(this@ProjectApplication, throwable)
+      defaultHandler?.uncaughtException(thread, throwable)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- create `ProjectApplication` to set a default `UncaughtExceptionHandler` that logs errors with `AppLogger`
- register `ProjectApplication` in the manifest

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c10c7f3ea08320a58673b75b0f2521