### PR TITLE
Add new chat action to chat list

### DIFF
--- a/app/src/main/java/com/example/projectandroid/ui/ChatListActivity.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/ChatListActivity.kt
@@ -95,6 +95,10 @@ class ChatListActivity : AppCompatActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
+            R.id.action_new_chat -> {
+                startActivity(Intent(this, SearchUserActivity::class.java))
+                true
+            }
             R.id.action_logout -> {
                 FirebaseAuth.getInstance().signOut()
                 val intent = Intent(this, LoginActivity::class.java)

--- a/app/src/main/res/menu/menu_chat_list.xml
+++ b/app/src/main/res/menu/menu_chat_list.xml
@@ -2,6 +2,11 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
+        android:id="@+id/action_new_chat"
+        android:title="@string/new_chat"
+        android:icon="@android:drawable/ic_menu_add"
+        app:showAsAction="ifRoom" />
+    <item
         android:id="@+id/action_logout"
         android:title="@string/logout"
         android:icon="@drawable/ic_logout"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,4 +11,5 @@
     <string name="error_network">Error de red</string>
     <string name="no_chats_placeholder">No tienes chats aún</string>
     <string name="share_logs">Compartir logs</string>
+    <string name="new_chat">Nuevo chat</string>
 </resources>


### PR DESCRIPTION
## Summary
- add "New chat" toolbar action that opens user search
- include menu and string resources for new chat action

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c24ad8be608320bf6dc42dc079f01c