### PR TITLE
Add toolbar to Login screen

### DIFF
--- a/app/src/main/java/com/example/projectandroid/ui/LoginActivity.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/LoginActivity.kt
@@ -9,6 +9,7 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.example.projectandroid.R
 import com.example.projectandroid.util.AppLogger
+import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.textfield.TextInputEditText
 import com.google.firebase.FirebaseNetworkException
@@ -21,6 +22,10 @@ class LoginActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_login)
+
+    val toolbar = findViewById<MaterialToolbar>(R.id.topAppBar)
+    setSupportActionBar(toolbar)
+    supportActionBar?.title = getString(R.string.login_title)
 
     val emailInput = findViewById<TextInputEditText>(R.id.editEmail)
     val passwordInput = findViewById<TextInputEditText>(R.id.editPassword)

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -6,6 +6,13 @@
     android:orientation="vertical"
     android:padding="16dp">
 
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/topAppBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorPrimary"
+        android:theme="@style/ThemeOverlay.Material3.Dark.ActionBar" />
+
     <com.google.android.material.textfield.TextInputLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
     <string name="no_chats_placeholder">No tienes chats aún</string>
     <string name="share_logs">Compartir logs</string>
     <string name="new_chat">Nuevo chat</string>
+    <string name="login_title">Iniciar sesión</string>
     <string name="register_title">Registro</string>
     <string name="search_user_title">Buscar usuario</string>
 </resources>


### PR DESCRIPTION
## Summary
- add MaterialToolbar to login layout
- configure LoginActivity to use toolbar with title "Iniciar sesión"
- provide string resource for login title

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c25076f1e88320980e583b4baf8940