### PR TITLE
Refactor ChatActivity Firestore add failure handling

### DIFF
--- a/app/src/main/java/com/example/projectandroid/ui/ChatActivity.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/ChatActivity.kt
@@ -94,8 +94,12 @@ class ChatActivity : AppCompatActivity() {
         "text" to text,
         "createdAt" to FieldValue.serverTimestamp(),
       )
-      ref.add(data).addOnFailureListener { e -> AppLogger.logError(this, e) }
-      ref.add(data).addOnFailureListener { e -> ErrorLogger.log(this, e) }
+      ref
+        .add(data)
+        .addOnFailureListener { e ->
+          AppLogger.logError(this, e)
+          ErrorLogger.log(this, e)
+        }
 
       //nuevo
 


### PR DESCRIPTION
## Summary
- Avoid duplicate message insertions by calling `ref.add(data)` once
- Chain `AppLogger` and `ErrorLogger` on a single `addOnFailureListener`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy; HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c2529023e483209635af57d433ee71