### PR TITLE
Replace Material3 text input styles with Material Components

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="AppTextInputLayout" parent="Widget.Material3.TextInputLayout">
+    <style name="AppTextInputLayout" parent="Widget.MaterialComponents.TextInputLayout">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_marginTop">16dp</item>
@@ -8,7 +8,7 @@
         <item name="android:hintTextColor">@color/md_theme_light_secondary</item>
     </style>
 
-    <style name="AppTextInputEditText" parent="Widget.Material3.TextInputEditText">
+    <style name="AppTextInputEditText" parent="Widget.MaterialComponents.TextInputEditText">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:padding">16dp</item>


### PR DESCRIPTION
## Summary
- Switch AppTextInputLayout and AppTextInputEditText to `Widget.MaterialComponents` parents to use supported text input styles

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68c257167b808320b25fa1e0ca44f68e