### PR TITLE
Use textColorHint for AppTextInputLayout

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -5,7 +5,7 @@
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_marginTop">16dp</item>
         <item name="android:padding">16dp</item>
-        <item name="android:hintTextColor">@color/md_theme_light_secondary</item>
+        <item name="android:textColorHint">@color/md_theme_light_secondary</item>
     </style>
 
     <style name="AppTextInputEditText" parent="Widget.MaterialComponents.TextInputEditText">


### PR DESCRIPTION
## Summary
- replace deprecated `android:hintTextColor` with `android:textColorHint` for `AppTextInputLayout`

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c257c882a48320894823984b2ce67a