### PR TITLE
Replace Material components with AppCompat

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,7 +36,6 @@ android {
 dependencies {
     // UI base
     implementation("androidx.appcompat:appcompat:1.7.1")
-   // implementation("com.google.android.material:material:1.13.0") // Material 3 reciente
     implementation("androidx.recyclerview:recyclerview:1.3.2")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
 

--- a/app/src/main/java/com/example/projectandroid/ui/ChatActivity.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/ChatActivity.kt
@@ -6,9 +6,9 @@ import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import com.google.android.material.appbar.MaterialToolbar
-import com.google.android.material.button.MaterialButton
-import com.google.android.material.textfield.TextInputEditText
+import androidx.appcompat.widget.Toolbar
+import android.widget.Button
+import android.widget.EditText
 import com.example.projectandroid.R
 import com.example.projectandroid.model.Message
 import com.google.firebase.auth.ktx.auth
@@ -23,8 +23,8 @@ class ChatActivity : AppCompatActivity() {
 
   private lateinit var recyclerView: RecyclerView
   private lateinit var adapter: ChatAdapter
-  private lateinit var messageInput: TextInputEditText
-  private lateinit var sendButton: MaterialButton
+  private lateinit var messageInput: EditText
+  private lateinit var sendButton: Button
   private lateinit var listenerRegistration: ListenerRegistration
 
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -51,7 +51,7 @@ class ChatActivity : AppCompatActivity() {
   private fun initChat(currentUid: String, recipientUid: String, recipientName: String) {
     setContentView(R.layout.activity_chat)
 
-    val toolbar = findViewById<MaterialToolbar>(R.id.topAppBar)
+    val toolbar = findViewById<Toolbar>(R.id.topAppBar)
     setSupportActionBar(toolbar)
     supportActionBar?.setDisplayHomeAsUpEnabled(true)
     supportActionBar?.title = recipientName

--- a/app/src/main/java/com/example/projectandroid/ui/ChatListActivity.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/ChatListActivity.kt
@@ -19,7 +19,7 @@ import com.example.projectandroid.util.AppLogger
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
-import com.google.android.material.appbar.MaterialToolbar
+import androidx.appcompat.widget.Toolbar
 import java.util.Locale
 
 class ChatListActivity : AppCompatActivity() {
@@ -40,7 +40,7 @@ class ChatListActivity : AppCompatActivity() {
         }
 
         setContentView(R.layout.activity_chat_list)
-        val toolbar = findViewById<MaterialToolbar>(R.id.topAppBar)
+        val toolbar = findViewById<Toolbar>(R.id.topAppBar)
         setSupportActionBar(toolbar)
 
         adapter = ChatListAdapter { room ->

--- a/app/src/main/java/com/example/projectandroid/ui/LoginActivity.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/LoginActivity.kt
@@ -9,9 +9,9 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.example.projectandroid.R
 import com.example.projectandroid.util.AppLogger
-import com.google.android.material.appbar.MaterialToolbar
-import com.google.android.material.button.MaterialButton
-import com.google.android.material.textfield.TextInputEditText
+import androidx.appcompat.widget.Toolbar
+import android.widget.Button
+import android.widget.EditText
 import com.google.firebase.FirebaseNetworkException
 import com.google.firebase.auth.FirebaseAuthInvalidCredentialsException
 import com.google.firebase.auth.FirebaseAuthInvalidUserException
@@ -23,14 +23,14 @@ class LoginActivity : AppCompatActivity() {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_login)
 
-    val toolbar = findViewById<MaterialToolbar>(R.id.topAppBar)
+    val toolbar = findViewById<Toolbar>(R.id.topAppBar)
     setSupportActionBar(toolbar)
     supportActionBar?.title = getString(R.string.login_title)
 
-    val emailInput = findViewById<TextInputEditText>(R.id.editEmail)
-    val passwordInput = findViewById<TextInputEditText>(R.id.editPassword)
-    val loginButton = findViewById<MaterialButton>(R.id.buttonLogin)
-    val registerButton = findViewById<MaterialButton>(R.id.buttonRegister)
+    val emailInput = findViewById<EditText>(R.id.editEmail)
+    val passwordInput = findViewById<EditText>(R.id.editPassword)
+    val loginButton = findViewById<Button>(R.id.buttonLogin)
+    val registerButton = findViewById<Button>(R.id.buttonRegister)
     val progressBar = findViewById<ProgressBar>(R.id.progressBar)
 
     loginButton.setOnClickListener {

--- a/app/src/main/java/com/example/projectandroid/ui/RegisterActivity.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/RegisterActivity.kt
@@ -8,9 +8,9 @@ import androidx.appcompat.app.AppCompatActivity
 import com.example.projectandroid.R
 import com.example.projectandroid.model.User
 import com.example.projectandroid.util.AppLogger
-import com.google.android.material.appbar.MaterialToolbar
-import com.google.android.material.button.MaterialButton
-import com.google.android.material.textfield.TextInputEditText
+import androidx.appcompat.widget.Toolbar
+import android.widget.Button
+import android.widget.EditText
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.auth.ktx.userProfileChangeRequest
 import com.google.firebase.firestore.ktx.firestore
@@ -21,14 +21,14 @@ class RegisterActivity : AppCompatActivity() {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_register)
 
-    val toolbar = findViewById<MaterialToolbar>(R.id.topAppBar)
+    val toolbar = findViewById<Toolbar>(R.id.topAppBar)
     setSupportActionBar(toolbar)
     supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
-    val nameInput = findViewById<TextInputEditText>(R.id.editName)
-    val emailInput = findViewById<TextInputEditText>(R.id.editEmail)
-    val passwordInput = findViewById<TextInputEditText>(R.id.editPassword)
-    val registerButton = findViewById<MaterialButton>(R.id.buttonRegister)
+    val nameInput = findViewById<EditText>(R.id.editName)
+    val emailInput = findViewById<EditText>(R.id.editEmail)
+    val passwordInput = findViewById<EditText>(R.id.editPassword)
+    val registerButton = findViewById<Button>(R.id.buttonRegister)
 
     registerButton.setOnClickListener {
       val name = nameInput.text.toString().trim()

--- a/app/src/main/java/com/example/projectandroid/ui/SearchUserActivity.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/SearchUserActivity.kt
@@ -9,7 +9,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.example.projectandroid.R
 import com.example.projectandroid.repository.UserRepository
 import com.example.projectandroid.util.AppLogger
-import com.google.android.material.appbar.MaterialToolbar
+import androidx.appcompat.widget.Toolbar
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
 
@@ -29,7 +29,7 @@ class SearchUserActivity : AppCompatActivity() {
 
         setContentView(R.layout.activity_search_user)
 
-        val toolbar = findViewById<MaterialToolbar>(R.id.topAppBar)
+        val toolbar = findViewById<Toolbar>(R.id.topAppBar)
         setSupportActionBar(toolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 

--- a/app/src/main/res/layout/activity_chat.xml
+++ b/app/src/main/res/layout/activity_chat.xml
@@ -5,12 +5,12 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <com.google.android.material.appbar.MaterialToolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/topAppBar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="?attr/colorPrimary"
-        android:theme="@style/ThemeOverlay.Material3.Dark.ActionBar" />
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerView"
@@ -24,26 +24,22 @@
         android:orientation="horizontal"
         android:padding="8dp">
 
-        <com.google.android.material.textfield.TextInputLayout
+        <androidx.appcompat.widget.AppCompatEditText
+            android:id="@+id/editMessage"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:hint="Escribe un mensaje">
+            android:hint="Escribe un mensaje"
+            android:padding="16dp" />
 
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/editMessage"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
-        </com.google.android.material.textfield.TextInputLayout>
-
-        <com.google.android.material.button.MaterialButton
+        <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/buttonSend"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="Enviar"
-            app:icon="@drawable/ic_send"
-            app:iconGravity="textStart"
-            app:iconPadding="0dp" />
+            android:drawableStart="@drawable/ic_send"
+            android:backgroundTint="?attr/colorPrimary"
+            android:textColor="@android:color/white" />
     </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/activity_chat_list.xml
+++ b/app/src/main/res/layout/activity_chat_list.xml
@@ -5,12 +5,12 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <com.google.android.material.appbar.MaterialToolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/topAppBar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="?attr/colorPrimary"
-        android:theme="@style/ThemeOverlay.Material3.Dark.ActionBar"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
         app:title="@string/chats_title" />
 
     <androidx.appcompat.widget.SearchView

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -6,43 +6,35 @@
     android:orientation="vertical"
     android:padding="16dp">
 
-    <com.google.android.material.appbar.MaterialToolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/topAppBar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="?attr/colorPrimary"
-        android:theme="@style/ThemeOverlay.Material3.Dark.ActionBar" />
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
 
-    <com.google.android.material.textfield.TextInputLayout
-        style="@style/AppTextInputLayout"
+    <androidx.appcompat.widget.AppCompatEditText
+        android:id="@+id/editEmail"
+        style="@style/AppEditText"
+        android:drawableStart="@drawable/ic_email"
         android:hint="Email"
-        app:startIconDrawable="@drawable/ic_email">
+        android:inputType="textEmailAddress" />
 
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/editEmail"
-            style="@style/AppTextInputEditText"
-            android:inputType="textEmailAddress" />
-    </com.google.android.material.textfield.TextInputLayout>
-
-    <com.google.android.material.textfield.TextInputLayout
-        style="@style/AppTextInputLayout"
+    <androidx.appcompat.widget.AppCompatEditText
+        android:id="@+id/editPassword"
+        style="@style/AppEditText"
+        android:drawableStart="@drawable/ic_lock"
         android:hint="Password"
-        app:startIconDrawable="@drawable/ic_lock">
+        android:inputType="textPassword" />
 
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/editPassword"
-            style="@style/AppTextInputEditText"
-            android:inputType="textPassword" />
-    </com.google.android.material.textfield.TextInputLayout>
-
-    <com.google.android.material.button.MaterialButton
+    <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/buttonLogin"
-        style="@style/AppMaterialButton"
+        style="@style/AppButton"
         android:text="Login" />
 
-    <com.google.android.material.button.MaterialButton
+    <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/buttonRegister"
-        style="@style/AppMaterialButton"
+        style="@style/AppButton"
         android:text="Register" />
 
     <ProgressBar

--- a/app/src/main/res/layout/activity_register.xml
+++ b/app/src/main/res/layout/activity_register.xml
@@ -6,48 +6,36 @@
     android:orientation="vertical"
     android:padding="16dp">
 
-    <com.google.android.material.appbar.MaterialToolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/topAppBar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="?attr/colorPrimary"
-        android:theme="@style/ThemeOverlay.Material3.Dark.ActionBar"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
         app:title="@string/register_title" />
 
-    <com.google.android.material.textfield.TextInputLayout
-        style="@style/AppTextInputLayout"
-        android:hint="Name"
-        app:startIconDrawable="@drawable/ic_person">
+    <androidx.appcompat.widget.AppCompatEditText
+        android:id="@+id/editName"
+        style="@style/AppEditText"
+        android:drawableStart="@drawable/ic_person"
+        android:hint="Name" />
 
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/editName"
-            style="@style/AppTextInputEditText" />
-    </com.google.android.material.textfield.TextInputLayout>
-
-    <com.google.android.material.textfield.TextInputLayout
-        style="@style/AppTextInputLayout"
+    <androidx.appcompat.widget.AppCompatEditText
+        android:id="@+id/editEmail"
+        style="@style/AppEditText"
+        android:drawableStart="@drawable/ic_email"
         android:hint="Email"
-        app:startIconDrawable="@drawable/ic_email">
+        android:inputType="textEmailAddress" />
 
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/editEmail"
-            style="@style/AppTextInputEditText"
-            android:inputType="textEmailAddress" />
-    </com.google.android.material.textfield.TextInputLayout>
-
-    <com.google.android.material.textfield.TextInputLayout
-        style="@style/AppTextInputLayout"
+    <androidx.appcompat.widget.AppCompatEditText
+        android:id="@+id/editPassword"
+        style="@style/AppEditText"
+        android:drawableStart="@drawable/ic_lock"
         android:hint="Password"
-        app:startIconDrawable="@drawable/ic_lock">
+        android:inputType="textPassword" />
 
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/editPassword"
-            style="@style/AppTextInputEditText"
-            android:inputType="textPassword" />
-    </com.google.android.material.textfield.TextInputLayout>
-
-    <com.google.android.material.button.MaterialButton
+    <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/buttonRegister"
-        style="@style/AppMaterialButton"
+        style="@style/AppButton"
         android:text="Register" />
 </LinearLayout>

--- a/app/src/main/res/layout/activity_search_user.xml
+++ b/app/src/main/res/layout/activity_search_user.xml
@@ -5,12 +5,12 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <com.google.android.material.appbar.MaterialToolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/topAppBar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="?attr/colorPrimary"
-        android:theme="@style/ThemeOverlay.Material3.Dark.ActionBar"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
         app:title="@string/search_user_title" />
 
     <androidx.appcompat.widget.SearchView

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,7 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Base.Theme.ProjectAndroid" parent="Theme.Material3.DayNight.NoActionBar">
+    <style name="Base.Theme.ProjectAndroid" parent="Theme.AppCompat.DayNight.NoActionBar">
         <!-- Customize your dark theme here. -->
-        <!-- <item name="colorPrimary">@color/my_dark_primary</item> -->
     </style>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,26 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="AppTextInputLayout" parent="Widget.Material3.TextInputLayout">
+    <style name="AppEditText" parent="Widget.AppCompat.EditText">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_marginTop">16dp</item>
         <item name="android:padding">16dp</item>
+        <item name="android:textColor">@color/md_theme_light_onSecondaryContainer</item>
         <item name="android:textColorHint">@color/md_theme_light_secondary</item>
     </style>
 
-    <style name="AppTextInputEditText" parent="Widget.Material3.TextInputEditText">
-        <item name="android:layout_width">match_parent</item>
-        <item name="android:layout_height">wrap_content</item>
-        <item name="android:padding">16dp</item>
-        <item name="android:textColor">@color/md_theme_light_onSecondaryContainer</item>
-    </style>
-
-    <style name="AppMaterialButton" parent="Widget.Material3.Button">
+    <style name="AppButton" parent="Widget.AppCompat.Button">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_marginTop">16dp</item>
         <item name="android:padding">16dp</item>
         <item name="android:backgroundTint">?attr/colorPrimary</item>
-        <item name="android:textColor">?attr/colorOnPrimary</item>
+        <item name="android:textColor">@android:color/white</item>
     </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,14 +1,9 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Base.Theme.ProjectAndroid" parent="Theme.Material3.DayNight.NoActionBar">
+    <style name="Base.Theme.ProjectAndroid" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="colorPrimary">@color/md_theme_light_primary</item>
-        <item name="colorOnPrimary">@color/md_theme_light_onPrimary</item>
-        <item name="colorPrimaryContainer">@color/md_theme_light_primaryContainer</item>
-        <item name="colorOnPrimaryContainer">@color/md_theme_light_onPrimaryContainer</item>
-        <item name="colorSecondary">@color/md_theme_light_secondary</item>
-        <item name="colorOnSecondary">@color/md_theme_light_onSecondary</item>
-        <item name="colorSecondaryContainer">@color/md_theme_light_secondaryContainer</item>
-        <item name="colorOnSecondaryContainer">@color/md_theme_light_onSecondaryContainer</item>
+        <item name="colorPrimaryDark">@color/md_theme_light_primary</item>
+        <item name="colorAccent">@color/md_theme_light_secondary</item>
     </style>
 
     <style name="Theme.ProjectAndroid" parent="Base.Theme.ProjectAndroid"/>


### PR DESCRIPTION
## Summary
- replace Material widgets in layouts and activities with AppCompat equivalents
- update styles and themes to use AppCompat parents
- drop unused Material Components library dependency

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c26863c79883208ffedc0b87e56e3b