### PR TITLE
chore: update compile and target sdk to 35

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,12 +6,12 @@ plugins {
 
 android {
     namespace = "com.example.projectandroid"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.example.projectandroid"
         minSdk = 24
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 1
         versionName = "1.0"
 


### PR DESCRIPTION
## Summary
- update compileSdk and targetSdk to 35

## Testing
- `sdkmanager --list` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `./gradlew build` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68c26a8e3c908320b32b02945142e46c