### PR TITLE
Validate extras in ChatActivity with logging

### DIFF
--- a/app/src/main/java/com/example/projectandroid/ui/ChatActivity.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/ChatActivity.kt
@@ -54,11 +54,16 @@ class ChatActivity : AppCompatActivity() {
       return
     }
 
-    val recipientUid = intent.getStringExtra("recipientUid")
-    val recipientName = intent.getStringExtra("recipientName")
-    if (recipientUid.isNullOrBlank() || recipientName.isNullOrBlank()) {
-      finish()
+    val recipientUid = intent.getStringExtra("recipientUid").takeUnless { it.isNullOrBlank() } ?: run {
+      val error = IllegalArgumentException("recipientUid extra is missing or blank")
+      AppLogger.logError(this, error)
+      ErrorLogger.log(this, error)
       return
+    }
+
+    val recipientName = intent.getStringExtra("recipientName").takeUnless { it.isNullOrBlank() } ?: run {
+      AppLogger.logWarn("ChatActivity", "recipientName extra missing or blank, using default", this)
+      "Usuario"
     }
 
     initChat(currentUser.uid, recipientUid, recipientName)


### PR DESCRIPTION
## Summary
- add descriptive validation for `recipientUid` and `recipientName` in `ChatActivity`
- default blank `recipientName` to "Usuario" and log missing extras

## Testing
- ⚠️ `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c4417777988320bfa1414376a1312b