### PR TITLE
Use stable message IDs for diffing

### DIFF
--- a/app/src/main/java/com/example/projectandroid/model/Message.kt
+++ b/app/src/main/java/com/example/projectandroid/model/Message.kt
@@ -3,6 +3,7 @@ package com.example.projectandroid.model
 import com.google.firebase.Timestamp
 
 data class Message(
+    val id: String = "",
     val senderId: String = "",
     val senderName: String = "",
     val text: String = "",

--- a/app/src/main/java/com/example/projectandroid/ui/ChatActivity.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/ChatActivity.kt
@@ -105,7 +105,9 @@ class ChatActivity : AppCompatActivity() {
           AppLogger.logError(this, error)
           return@addSnapshotListener
         }
-        val messages = value?.documents?.mapNotNull { it.toObject(Message::class.java) } ?: return@addSnapshotListener
+        val messages = value?.documents?.mapNotNull { doc ->
+          doc.toObject(Message::class.java)?.copy(id = doc.id)
+        } ?: return@addSnapshotListener
         adapter.submitList(messages)
         if (adapter.itemCount > 0) recyclerView.smoothScrollToPosition(adapter.itemCount - 1)
       }

--- a/app/src/main/java/com/example/projectandroid/ui/ChatAdapter.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/ChatAdapter.kt
@@ -87,7 +87,7 @@ class ChatAdapter(
     companion object {
         private val DIFF_CALLBACK = object : DiffUtil.ItemCallback<Message>() {
             override fun areItemsTheSame(oldItem: Message, newItem: Message): Boolean {
-                return oldItem.createdAt == newItem.createdAt
+                return oldItem.id == newItem.id
             }
 
             override fun areContentsTheSame(oldItem: Message, newItem: Message): Boolean {


### PR DESCRIPTION
## Summary
- add `id` field to `Message`
- use message IDs in `ChatAdapter`'s diffing
- map Firestore document IDs when building `Message`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c443bee3c08320ad575d6d301a44a7