### PR TITLE
Use custom vector icons for bottom navigation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,6 +17,9 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        vectorDrawables {
+            useSupportLibrary = true
+        }
     }
 
     buildTypes {

--- a/app/src/main/res/drawable/ic_chats.xml
+++ b/app/src/main/res/drawable/ic_chats.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/black"
+        android:pathData="M20 2H4c-1.1 0-2 .9-2 2v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-2 9H6V9h12v2zm0-3H6V6h12v2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_search.xml
+++ b/app/src/main/res/drawable/ic_search.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/black"
+        android:pathData="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 5L20.49 19l-5-5zm-5 0C8.01 14 6 11.99 6 9.5S8.01 5 10.5 5 15 7.01 15 9.5 12.99 14 10.5 14z"/>
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -15,6 +15,8 @@
         android:id="@+id/bottomNavigation"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:menu="@menu/menu_bottom_nav" />
+        app:menu="@menu/menu_bottom_nav"
+        app:itemIconTint="@color/black"
+        app:itemTextColor="@color/black" />
 
 </LinearLayout>

--- a/app/src/main/res/menu/menu_bottom_nav.xml
+++ b/app/src/main/res/menu/menu_bottom_nav.xml
@@ -3,11 +3,11 @@
     <item
         android:id="@+id/navigation_chats"
         android:title="Chats"
-        android:icon="@android:drawable/ic_dialog_email" />
+        android:icon="@drawable/ic_chats" />
     <item
         android:id="@+id/navigation_search"
         android:title="Buscar"
-        android:icon="@android:drawable/ic_menu_search" />
+        android:icon="@drawable/ic_search" />
     <item
         android:id="@+id/navigation_profile"
         android:title="Perfil"


### PR DESCRIPTION
## Summary
- replace system icons with custom `ic_chats` and `ic_search` vectors
- add explicit icon and text tint colors to `BottomNavigationView`
- enable support library handling for vector drawables

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c44725b07083209ef7269e7363577f