### PR TITLE
Add logout button and user info display in profile

### DIFF
--- a/app/src/main/java/com/example/projectandroid/ui/ProfileFragment.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/ProfileFragment.kt
@@ -1,11 +1,15 @@
 package com.example.projectandroid.ui
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import android.widget.TextView
 import androidx.fragment.app.Fragment
 import com.example.projectandroid.R
+import com.google.firebase.auth.FirebaseAuth
 
 class ProfileFragment : Fragment() {
     override fun onCreateView(
@@ -14,5 +18,21 @@ class ProfileFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         return inflater.inflate(R.layout.fragment_profile, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val user = FirebaseAuth.getInstance().currentUser
+        view.findViewById<TextView>(R.id.textUserName).text =
+            "Nombre: ${user?.displayName ?: ""}"
+        view.findViewById<TextView>(R.id.textUserEmail).text =
+            "Correo: ${user?.email ?: ""}"
+
+        view.findViewById<Button>(R.id.buttonLogout).setOnClickListener {
+            FirebaseAuth.getInstance().signOut()
+            startActivity(Intent(requireContext(), LoginActivity::class.java))
+            requireActivity().finish()
+        }
     }
 }

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -10,4 +10,22 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="Perfil" />
+
+    <TextView
+        android:id="@+id/textUserName"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Nombre:" />
+
+    <TextView
+        android:id="@+id/textUserEmail"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Correo:" />
+
+    <Button
+        android:id="@+id/buttonLogout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/logout" />
 </LinearLayout>


### PR DESCRIPTION
## Summary
- Show user name and email in profile screen
- Add logout button that signs out and redirects to login

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden" )*


------
https://chatgpt.com/codex/tasks/task_e_68c44943d95c832097626851fcd8cc92