### PR TITLE
Handle missing chat extras safely

### DIFF
--- a/app/src/main/java/com/example/projectandroid/ui/ChatActivity.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/ChatActivity.kt
@@ -58,12 +58,16 @@ class ChatActivity : AppCompatActivity() {
       val error = IllegalArgumentException("recipientUid extra is missing or blank")
       AppLogger.logError(this, error)
       ErrorLogger.log(this, error)
+      finish()
       return
     }
 
     val recipientName = intent.getStringExtra("recipientName").takeUnless { it.isNullOrBlank() } ?: run {
-      AppLogger.logWarn("ChatActivity", "recipientName extra missing or blank, using default", this)
-      "Usuario"
+      val error = IllegalArgumentException("recipientName extra is missing or blank")
+      AppLogger.logError(this, error)
+      ErrorLogger.log(this, error)
+      finish()
+      return
     }
 
     initChat(currentUser.uid, recipientUid, recipientName)

--- a/app/src/main/java/com/example/projectandroid/ui/ChatListFragment.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/ChatListFragment.kt
@@ -18,6 +18,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.example.projectandroid.R
 import com.example.projectandroid.model.ChatRoom
 import com.example.projectandroid.util.AppLogger
+import com.example.projectandroid.util.ErrorLogger
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
@@ -48,9 +49,16 @@ class ChatListFragment : Fragment() {
         (requireActivity() as androidx.appcompat.app.AppCompatActivity).setSupportActionBar(toolbar)
 
         adapter = ChatListAdapter { room ->
+            val uid = room.contactUid.takeUnless { it.isBlank() }
+            val name = room.contactName.takeUnless { it.isBlank() }
+            if (uid == null || name == null) {
+                val error = IllegalArgumentException("ChatRoom missing contactUid or contactName")
+                ErrorLogger.log(requireContext(), error)
+                return@ChatListAdapter
+            }
             val intent = Intent(requireContext(), ChatActivity::class.java).apply {
-                putExtra("recipientUid", room.contactUid)
-                putExtra("recipientName", room.contactName)
+                putExtra("recipientUid", uid)
+                putExtra("recipientName", name)
             }
             startActivity(intent)
         }

--- a/app/src/main/java/com/example/projectandroid/ui/SearchUserFragment.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/SearchUserFragment.kt
@@ -13,6 +13,7 @@ import androidx.appcompat.widget.Toolbar
 import com.example.projectandroid.R
 import com.example.projectandroid.repository.UserRepository
 import com.example.projectandroid.util.AppLogger
+import com.example.projectandroid.util.ErrorLogger
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
 
@@ -42,9 +43,16 @@ class SearchUserFragment : Fragment() {
         (requireActivity() as androidx.appcompat.app.AppCompatActivity).setSupportActionBar(toolbar)
 
         adapter = UserAdapter { user ->
+            val uid = user.uid.takeUnless { it.isBlank() }
+            val name = user.displayName.takeUnless { it.isBlank() }
+            if (uid == null || name == null) {
+                val error = IllegalArgumentException("User missing uid or displayName")
+                ErrorLogger.log(requireContext(), error)
+                return@UserAdapter
+            }
             val intent = Intent(requireContext(), ChatActivity::class.java).apply {
-                putExtra("recipientUid", user.uid)
-                putExtra("recipientName", user.displayName)
+                putExtra("recipientUid", uid)
+                putExtra("recipientName", name)
             }
             startActivity(intent)
         }


### PR DESCRIPTION
## Summary
- Guard ChatListFragment and SearchUserFragment against empty contact data before starting ChatActivity
- Validate ChatActivity intent extras; log failures and close activity when data is missing

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c44aa0d6f883208eaf079c23e17f00