### PR TITLE
Use white tint for bottom navigation icons

### DIFF
--- a/app/src/main/res/color/bottom_nav_colors.xml
+++ b/app/src/main/res/color/bottom_nav_colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/white"/>
+</selector>

--- a/app/src/main/res/drawable/ic_chats.xml
+++ b/app/src/main/res/drawable/ic_chats.xml
@@ -2,7 +2,8 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:viewportHeight="24"
+    android:tint="@color/white">
     <path
         android:fillColor="@android:color/black"
         android:pathData="M20 2H4c-1.1 0-2 .9-2 2v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-2 9H6V9h12v2zm0-3H6V6h12v2z"/>

--- a/app/src/main/res/drawable/ic_email.xml
+++ b/app/src/main/res/drawable/ic_email.xml
@@ -2,7 +2,8 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:viewportHeight="24"
+    android:tint="@color/white">
     <path
         android:fillColor="@android:color/black"
         android:pathData="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.89 2 1.99 2H20c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/>

--- a/app/src/main/res/drawable/ic_lock.xml
+++ b/app/src/main/res/drawable/ic_lock.xml
@@ -2,7 +2,8 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:viewportHeight="24"
+    android:tint="@color/white">
     <path
         android:fillColor="@android:color/black"
         android:pathData="M12 17c1.1 0 2-.9 2-2v-2c0-1.1-.9-2-2-2s-2 .9-2 2v2c0 1.1.9 2 2 2zm6-6h-1V9c0-2.76-2.24-5-5-5S7 6.24 7 9v2H6c-1.1 0-2 .9-2 2v8c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-8c0-1.1-.9-2-2-2zm-6-6c1.66 0 3 1.34 3 3v2H9V9c0-1.66 1.34-3 3-3z"/>

--- a/app/src/main/res/drawable/ic_logout.xml
+++ b/app/src/main/res/drawable/ic_logout.xml
@@ -2,7 +2,8 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:viewportHeight="24"
+    android:tint="@color/white">
     <path
         android:fillColor="@android:color/black"
         android:pathData="M17,7l-1.41,1.41L18.17,11H8v2h10.17l-2.58,2.59L17,17l5,-5zM4,5h7V3H4c-1.1,0-2,0.9-2,2v14c0,1.1,0.9,2,2,2h7v-2H4V5z"/>

--- a/app/src/main/res/drawable/ic_person.xml
+++ b/app/src/main/res/drawable/ic_person.xml
@@ -2,7 +2,8 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:viewportHeight="24"
+    android:tint="@color/white">
     <path
         android:fillColor="@android:color/black"
         android:pathData="M12 12c2.7 0 5-2.3 5-5s-2.3-5-5-5-5 2.3-5 5 2.3 5 5 5zm0 2c-3.3 0-10 1.7-10 5v3h20v-3c0-3.3-6.7-5-10-5z"/>

--- a/app/src/main/res/drawable/ic_search.xml
+++ b/app/src/main/res/drawable/ic_search.xml
@@ -2,7 +2,8 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:viewportHeight="24"
+    android:tint="@color/white">
     <path
         android:fillColor="@android:color/black"
         android:pathData="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 5L20.49 19l-5-5zm-5 0C8.01 14 6 11.99 6 9.5S8.01 5 10.5 5 15 7.01 15 9.5 12.99 14 10.5 14z"/>

--- a/app/src/main/res/drawable/ic_send.xml
+++ b/app/src/main/res/drawable/ic_send.xml
@@ -2,7 +2,8 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:viewportHeight="24"
+    android:tint="@color/white">
     <path
         android:fillColor="@android:color/black"
         android:pathData="M2,21L23,12L2,3V10L17,12L2,14V21Z"/>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -16,7 +16,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:menu="@menu/menu_bottom_nav"
-        app:itemIconTint="@color/black"
-        app:itemTextColor="@color/black" />
+        app:itemIconTint="@color/bottom_nav_colors"
+        app:itemTextColor="@color/bottom_nav_colors" />
 
 </LinearLayout>


### PR DESCRIPTION
## Summary
- add bottom_nav_colors color resource referencing white
- apply bottom_nav_colors to BottomNavigationView icon and text tint
- tint vector drawables white for monochrome icons

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c451c38e888320bdfb58dd6c387c2e