### PR TITLE
Implement Firebase Cloud Messaging notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /.gradle/
 /build/
 app/build/
+# Firebase Cloud Functions
+functions/node_modules/
 # Ignore local SDK configuration
 /local.properties
 /.idea/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -61,6 +61,7 @@ dependencies {
     implementation("com.google.firebase:firebase-analytics")
     implementation("com.google.firebase:firebase-auth-ktx")
     implementation("com.google.firebase:firebase-firestore-ktx")
+    implementation("com.google.firebase:firebase-messaging")
     // Imágenes: Firebase Storage
     implementation("com.google.firebase:firebase-storage-ktx:21.0.0")
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
 
     <application
         android:name=".ProjectApplication"
@@ -44,6 +45,14 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_paths" />
         </provider>
+
+        <service
+            android:name=".MessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/projectandroid/MessagingService.kt
+++ b/app/src/main/java/com/example/projectandroid/MessagingService.kt
@@ -1,0 +1,64 @@
+package com.example.projectandroid
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.google.firebase.auth.ktx.auth
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+
+class MessagingService : FirebaseMessagingService() {
+
+  override fun onMessageReceived(message: RemoteMessage) {
+    val title = message.notification?.title ?: "Nuevo mensaje"
+    val body = message.notification?.body ?: ""
+
+    val intent = Intent(this, MainActivity::class.java).apply {
+      addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+    }
+
+    val pendingIntent = PendingIntent.getActivity(
+      this,
+      0,
+      intent,
+      PendingIntent.FLAG_ONE_SHOT or PendingIntent.FLAG_IMMUTABLE
+    )
+
+    val channelId = "messages"
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      val channel = NotificationChannel(
+        channelId,
+        "Mensajes",
+        NotificationManager.IMPORTANCE_HIGH
+      )
+      (getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager)
+        .createNotificationChannel(channel)
+    }
+
+    val notification = NotificationCompat.Builder(this, channelId)
+      .setSmallIcon(R.drawable.ic_chats)
+      .setContentTitle(title)
+      .setContentText(body)
+      .setAutoCancel(true)
+      .setContentIntent(pendingIntent)
+      .build()
+
+    NotificationManagerCompat.from(this).notify(0, notification)
+  }
+
+  override fun onNewToken(token: String) {
+    super.onNewToken(token)
+
+    val currentUser = Firebase.auth.currentUser ?: return
+    Firebase.firestore.collection("users")
+      .document(currentUser.uid)
+      .update("fcmToken", token)
+  }
+}

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,0 +1,30 @@
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
+
+admin.initializeApp();
+
+exports.sendMessageNotification = functions.firestore
+  .document('rooms/{roomId}/messages/{messageId}')
+  .onCreate(async (snap, context) => {
+    const message = snap.data();
+    const roomId = context.params.roomId || '';
+    const participants = roomId.split('_');
+    const recipientId = participants.find(id => id !== message.senderId);
+    if (!recipientId) {
+      return null;
+    }
+
+    const userDoc = await admin.firestore().collection('users').doc(recipientId).get();
+    const token = userDoc.data()?.fcmToken;
+    if (!token) {
+      return null;
+    }
+
+    return admin.messaging().send({
+      token,
+      notification: {
+        title: message.senderName || 'Nuevo mensaje',
+        body: message.text || '',
+      },
+    });
+  });

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "functions",
+  "engines": {
+    "node": "20"
+  },
+  "dependencies": {
+    "firebase-admin": "^11.10.1",
+    "firebase-functions": "^5.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- Add Firebase Cloud Messaging dependency and service with token refresh support.
- Register messaging service and required permission in Android manifest.
- Provide Cloud Function example to push FCM notifications when new messages are stored.

## Testing
- `node --check functions/index.js`
- `./gradlew test` *(fails: Unable to tunnel through proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c45b0136bc8320b1b43a8d3d4b6bc0