### PR TITLE
Define bottom navigation color states

### DIFF
--- a/app/src/main/res/color/bottom_nav_colors.xml
+++ b/app/src/main/res/color/bottom_nav_colors.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:color="@color/white"/>
+    <item android:state_checked="true" android:color="@color/white" />
+    <item android:state_checked="false" android:color="#80FFFFFF" />
 </selector>


### PR DESCRIPTION
## Summary
- add selector for bottom navigation items to display white when checked and grey when unchecked

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c45e7d018c83208c06bbcc3f0c7685