### PR TITLE
Refactor auth forms to use Material text fields

### DIFF
--- a/app/src/main/java/com/example/projectandroid/ui/LoginActivity.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/LoginActivity.kt
@@ -11,7 +11,8 @@ import com.example.projectandroid.R
 import com.example.projectandroid.util.AppLogger
 import androidx.appcompat.widget.Toolbar
 import android.widget.Button
-import android.widget.EditText
+import com.google.android.material.textfield.TextInputEditText
+import com.google.android.material.textfield.TextInputLayout
 import com.google.firebase.FirebaseNetworkException
 import com.google.firebase.auth.FirebaseAuthInvalidCredentialsException
 import com.google.firebase.auth.FirebaseAuthInvalidUserException
@@ -34,8 +35,10 @@ class LoginActivity : AppCompatActivity() {
     setSupportActionBar(toolbar)
     supportActionBar?.title = getString(R.string.login_title)
 
-    val emailInput = findViewById<EditText>(R.id.editEmail)
-    val passwordInput = findViewById<EditText>(R.id.editPassword)
+    val emailLayout = findViewById<TextInputLayout>(R.id.emailLayout)
+    val emailInput = findViewById<TextInputEditText>(R.id.editEmail)
+    val passwordLayout = findViewById<TextInputLayout>(R.id.passwordLayout)
+    val passwordInput = findViewById<TextInputEditText>(R.id.editPassword)
     val loginButton = findViewById<Button>(R.id.buttonLogin)
     val registerButton = findViewById<Button>(R.id.buttonRegister)
     val progressBar = findViewById<ProgressBar>(R.id.progressBar)
@@ -44,13 +47,16 @@ class LoginActivity : AppCompatActivity() {
       val email = emailInput.text.toString().trim()
       val password = passwordInput.text.toString().trim()
 
+      emailLayout.error = null
+      passwordLayout.error = null
+
       var isValid = true
       if (!Patterns.EMAIL_ADDRESS.matcher(email).matches()) {
-        emailInput.error = getString(R.string.invalid_email)
+        emailLayout.error = getString(R.string.invalid_email)
         isValid = false
       }
       if (password.length < 6) {
-        passwordInput.error = getString(R.string.invalid_password)
+        passwordLayout.error = getString(R.string.invalid_password)
         isValid = false
       }
       if (!isValid) return@setOnClickListener

--- a/app/src/main/java/com/example/projectandroid/ui/RegisterActivity.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/RegisterActivity.kt
@@ -10,7 +10,8 @@ import com.example.projectandroid.model.User
 import com.example.projectandroid.util.AppLogger
 import androidx.appcompat.widget.Toolbar
 import android.widget.Button
-import android.widget.EditText
+import com.google.android.material.textfield.TextInputEditText
+import com.google.android.material.textfield.TextInputLayout
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.auth.ktx.userProfileChangeRequest
 import com.google.firebase.firestore.ktx.firestore
@@ -25,9 +26,12 @@ class RegisterActivity : AppCompatActivity() {
     setSupportActionBar(toolbar)
     supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
-    val nameInput = findViewById<EditText>(R.id.editName)
-    val emailInput = findViewById<EditText>(R.id.editEmail)
-    val passwordInput = findViewById<EditText>(R.id.editPassword)
+    val nameLayout = findViewById<TextInputLayout>(R.id.nameLayout)
+    val nameInput = findViewById<TextInputEditText>(R.id.editName)
+    val emailLayout = findViewById<TextInputLayout>(R.id.emailLayout)
+    val emailInput = findViewById<TextInputEditText>(R.id.editEmail)
+    val passwordLayout = findViewById<TextInputLayout>(R.id.passwordLayout)
+    val passwordInput = findViewById<TextInputEditText>(R.id.editPassword)
     val registerButton = findViewById<Button>(R.id.buttonRegister)
 
     registerButton.setOnClickListener {
@@ -35,17 +39,21 @@ class RegisterActivity : AppCompatActivity() {
       val email = emailInput.text.toString().trim()
       val password = passwordInput.text.toString().trim()
 
+      nameLayout.error = null
+      emailLayout.error = null
+      passwordLayout.error = null
+
       var isValid = true
       if (name.isBlank()) {
-        nameInput.error = getString(R.string.required_field)
+        nameLayout.error = getString(R.string.required_field)
         isValid = false
       }
       if (!Patterns.EMAIL_ADDRESS.matcher(email).matches()) {
-        emailInput.error = getString(R.string.invalid_email)
+        emailLayout.error = getString(R.string.invalid_email)
         isValid = false
       }
       if (password.length < 6) {
-        passwordInput.error = getString(R.string.invalid_password)
+        passwordLayout.error = getString(R.string.invalid_password)
         isValid = false
       }
       if (!isValid) return@setOnClickListener

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -28,31 +28,53 @@
                 android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
         </com.google.android.material.appbar.AppBarLayout>
 
-        <androidx.appcompat.widget.AppCompatEditText
-            android:id="@+id/editEmail"
-            style="@style/AppEditText"
-            android:drawableStart="@drawable/ic_email"
-            android:hint="Email"
-            android:inputType="textEmailAddress"
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/emailLayout"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            app:boxBackgroundMode="outline"
+            app:startIconDrawable="@drawable/ic_email"
             app:layout_constraintTop_toBottomOf="@id/appBar"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+            app:layout_constraintEnd_toEndOf="parent">
 
-        <androidx.appcompat.widget.AppCompatEditText
-            android:id="@+id/editPassword"
-            style="@style/AppEditText"
-            android:drawableStart="@drawable/ic_lock"
-            android:hint="Password"
-            android:inputType="textPassword"
-            app:layout_constraintTop_toBottomOf="@id/editEmail"
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/editEmail"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="Email"
+                android:inputType="textEmailAddress"
+                android:textColor="@color/md_theme_light_onSecondaryContainer"
+                android:textColorHint="@color/md_theme_light_secondary" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/passwordLayout"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            app:boxBackgroundMode="outline"
+            app:startIconDrawable="@drawable/ic_lock"
+            app:layout_constraintTop_toBottomOf="@id/emailLayout"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+            app:layout_constraintEnd_toEndOf="parent">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/editPassword"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="Password"
+                android:inputType="textPassword"
+                android:textColor="@color/md_theme_light_onSecondaryContainer"
+                android:textColorHint="@color/md_theme_light_secondary" />
+        </com.google.android.material.textfield.TextInputLayout>
 
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/buttonLogin"
             style="@style/AppButton"
             android:text="Login"
-            app:layout_constraintTop_toBottomOf="@id/editPassword"
+            app:layout_constraintTop_toBottomOf="@id/passwordLayout"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent" />
 

--- a/app/src/main/res/layout/activity_register.xml
+++ b/app/src/main/res/layout/activity_register.xml
@@ -23,40 +23,73 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <androidx.appcompat.widget.AppCompatEditText
-            android:id="@+id/editName"
-            style="@style/AppEditText"
-            android:drawableStart="@drawable/ic_person"
-            android:hint="Name"
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/nameLayout"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            app:boxBackgroundMode="outline"
+            app:startIconDrawable="@drawable/ic_person"
             app:layout_constraintTop_toBottomOf="@id/topAppBar"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+            app:layout_constraintEnd_toEndOf="parent">
 
-        <androidx.appcompat.widget.AppCompatEditText
-            android:id="@+id/editEmail"
-            style="@style/AppEditText"
-            android:drawableStart="@drawable/ic_email"
-            android:hint="Email"
-            android:inputType="textEmailAddress"
-            app:layout_constraintTop_toBottomOf="@id/editName"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/editName"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="Name"
+                android:textColor="@color/md_theme_light_onSecondaryContainer"
+                android:textColorHint="@color/md_theme_light_secondary" />
+        </com.google.android.material.textfield.TextInputLayout>
 
-        <androidx.appcompat.widget.AppCompatEditText
-            android:id="@+id/editPassword"
-            style="@style/AppEditText"
-            android:drawableStart="@drawable/ic_lock"
-            android:hint="Password"
-            android:inputType="textPassword"
-            app:layout_constraintTop_toBottomOf="@id/editEmail"
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/emailLayout"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            app:boxBackgroundMode="outline"
+            app:startIconDrawable="@drawable/ic_email"
+            app:layout_constraintTop_toBottomOf="@id/nameLayout"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+            app:layout_constraintEnd_toEndOf="parent">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/editEmail"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="Email"
+                android:inputType="textEmailAddress"
+                android:textColor="@color/md_theme_light_onSecondaryContainer"
+                android:textColorHint="@color/md_theme_light_secondary" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/passwordLayout"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            app:boxBackgroundMode="outline"
+            app:startIconDrawable="@drawable/ic_lock"
+            app:layout_constraintTop_toBottomOf="@id/emailLayout"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/editPassword"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="Password"
+                android:inputType="textPassword"
+                android:textColor="@color/md_theme_light_onSecondaryContainer"
+                android:textColorHint="@color/md_theme_light_secondary" />
+        </com.google.android.material.textfield.TextInputLayout>
 
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/buttonRegister"
             style="@style/AppButton"
             android:text="Register"
-            app:layout_constraintTop_toBottomOf="@id/editPassword"
+            app:layout_constraintTop_toBottomOf="@id/passwordLayout"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent" />
 


### PR DESCRIPTION
## Summary
- Swap AppCompatEditText fields for TextInputLayout/TextInputEditText in login and register screens
- Apply outlined Material styling with start icons for each field
- Validate input using TextInputLayout errors for clearer feedback

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c45ef7c2a88320b8a96288aa57ba40