### PR TITLE
Refine button styling with Material components

### DIFF
--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -70,7 +70,7 @@
                 android:textColorHint="@color/md_theme_light_secondary" />
         </com.google.android.material.textfield.TextInputLayout>
 
-        <androidx.appcompat.widget.AppCompatButton
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/buttonLogin"
             style="@style/AppButton"
             android:text="Login"
@@ -78,7 +78,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent" />
 
-        <androidx.appcompat.widget.AppCompatButton
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/buttonRegister"
             style="@style/AppButton"
             android:text="Register"

--- a/app/src/main/res/layout/activity_register.xml
+++ b/app/src/main/res/layout/activity_register.xml
@@ -85,7 +85,7 @@
                 android:textColorHint="@color/md_theme_light_secondary" />
         </com.google.android.material.textfield.TextInputLayout>
 
-        <androidx.appcompat.widget.AppCompatButton
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/buttonRegister"
             style="@style/AppButton"
             android:text="Register"

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -35,8 +35,9 @@
         app:layout_constraintTop_toBottomOf="@id/textUserName"
         app:layout_constraintBottom_toTopOf="@id/buttonLogout" />
 
-    <Button
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/buttonLogout"
+        style="@style/AppButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/logout"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -9,12 +9,13 @@
         <item name="android:textColorHint">@color/md_theme_light_secondary</item>
     </style>
 
-    <style name="AppButton" parent="Widget.AppCompat.Button">
+    <style name="AppButton" parent="Widget.MaterialComponents.Button">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_marginTop">16dp</item>
         <item name="android:padding">16dp</item>
         <item name="android:backgroundTint">?attr/colorPrimary</item>
         <item name="android:textColor">@android:color/white</item>
+        <item name="cornerRadius">8dp</item>
     </style>
 </resources>


### PR DESCRIPTION
## Summary
- update `AppButton` style to inherit from Material button and round corners
- switch login, register, and profile layouts to use MaterialButton with shared style

## Testing
- `./gradlew test` (fails: Unable to tunnel through proxy)
- `adb devices` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68c460d22a208320be8c67da0313fcac