### PR TITLE
Ajuste de gravedad en mensajes de chat

### DIFF
--- a/app/src/main/java/com/example/projectandroid/ui/ChatAdapter.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/ChatAdapter.kt
@@ -2,6 +2,7 @@ package com.example.projectandroid.ui
 
 import com.bumptech.glide.Glide
 
+import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -71,6 +72,24 @@ class ChatAdapter(
             Glide.with(holder.itemView.context)
                 .load(message.imageUrl)
                 .into(holder.imageView)
+        }
+
+        if (message.senderId == myUid) {
+            holder.root.gravity = Gravity.END
+            if (holder.messageText.visibility == View.VISIBLE) {
+                holder.messageText.setBackgroundResource(R.drawable.bg_bubble_me)
+            }
+            if (holder.imageView.visibility == View.VISIBLE) {
+                holder.imageView.setBackgroundResource(R.drawable.bg_bubble_me)
+            }
+        } else {
+            holder.root.gravity = Gravity.START
+            if (holder.messageText.visibility == View.VISIBLE) {
+                holder.messageText.setBackgroundResource(R.drawable.bg_bubble_other)
+            }
+            if (holder.imageView.visibility == View.VISIBLE) {
+                holder.imageView.setBackgroundResource(R.drawable.bg_bubble_other)
+            }
         }
 
         val ts = message.createdAt

--- a/app/src/main/res/layout/item_message.xml
+++ b/app/src/main/res/layout/item_message.xml
@@ -4,7 +4,8 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:padding="8dp">
+    android:padding="8dp"
+    android:gravity="start">
 
     <TextView
         android:id="@+id/textMessage"


### PR DESCRIPTION
## Summary
- Ajuste de gravedad y fondo de burbujas según el remitente en `ChatAdapter`
- Se añade gravedad inicial al layout de mensaje para respetar la alineación

## Testing
- `./gradlew test` *(falla: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c4649d7d688320b5cfed16f0a633ef