### PR TITLE
Format chat timestamps with 12-hour clock

### DIFF
--- a/app/src/main/java/com/example/projectandroid/ui/ChatAdapter.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/ChatAdapter.kt
@@ -28,7 +28,7 @@ class ChatAdapter(
         val imageView: ImageView = view.findViewById(R.id.imageMessage)
     }
 
-    private val timeFormatter = SimpleDateFormat("HH:mm", Locale.getDefault())
+    private val timeFormatter = SimpleDateFormat("hh:mm a", Locale.getDefault())
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MessageViewHolder {
         val view = LayoutInflater.from(parent.context)
@@ -93,7 +93,13 @@ class ChatAdapter(
         }
 
         val ts = message.createdAt
-        holder.timeText.text = ts?.toDate()?.let { timeFormatter.format(it) } ?: ""
+        if (ts != null) {
+            holder.timeText.text = timeFormatter.format(ts.toDate())
+            holder.timeText.visibility = View.VISIBLE
+        } else {
+            holder.timeText.text = ""
+            holder.timeText.visibility = View.INVISIBLE
+        }
     }
 
 


### PR DESCRIPTION
## Summary
- switch chat timestamp format to 12-hour clock with AM/PM
- ensure message time visibility reflects presence of timestamp

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c4688146d08320b9c5c17b11817b53