### PR TITLE
feat: enable profile photo and name editing

### DIFF
--- a/app/src/main/java/com/example/projectandroid/ui/ProfileFragment.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/ProfileFragment.kt
@@ -1,17 +1,37 @@
 package com.example.projectandroid.ui
 
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
+import android.widget.ImageView
 import android.widget.TextView
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.Fragment
+import com.bumptech.glide.Glide
 import com.example.projectandroid.R
+import com.example.projectandroid.model.User
+import com.google.android.material.textfield.TextInputEditText
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.ktx.userProfileChangeRequest
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
+import com.google.firebase.storage.ktx.storage
 
 class ProfileFragment : Fragment() {
+    private var imageUri: Uri? = null
+
+    private val pickImage = registerForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
+        if (uri != null) {
+            imageUri = uri
+            view?.findViewById<ImageView>(R.id.imageProfile)?.let { imageView ->
+                Glide.with(this).load(uri).into(imageView)
+            }
+        }
+    }
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -24,12 +44,51 @@ class ProfileFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         val user = FirebaseAuth.getInstance().currentUser
-        view.findViewById<TextView>(R.id.textUserName).text =
-            "Nombre: ${user?.displayName ?: ""}"
-        view.findViewById<TextView>(R.id.textUserEmail).text =
-            "Correo: ${user?.email ?: ""}"
 
-        view.findViewById<Button>(R.id.buttonLogout).setOnClickListener {
+        val imageProfile = view.findViewById<ImageView>(R.id.imageProfile)
+        val nameInput = view.findViewById<TextInputEditText>(R.id.editDisplayName)
+        val emailText = view.findViewById<TextView>(R.id.textUserEmail)
+        val buttonSave = view.findViewById<Button>(R.id.buttonSave)
+        val buttonLogout = view.findViewById<Button>(R.id.buttonLogout)
+
+        nameInput.setText(user?.displayName ?: "")
+        emailText.text = "Correo: ${user?.email ?: ""}"
+        Glide.with(this).load(user?.photoUrl).placeholder(R.drawable.ic_person).into(imageProfile)
+
+        imageProfile.setOnClickListener { pickImage.launch("image/*") }
+
+        buttonSave.setOnClickListener {
+            val uid = user?.uid ?: return@setOnClickListener
+            val name = nameInput.text.toString().trim()
+            val storageRef = Firebase.storage.reference.child("profileImages/$uid.jpg")
+
+            fun updateProfile(photoUri: Uri?) {
+                val profileUpdates = userProfileChangeRequest {
+                    displayName = name
+                    this.photoUri = photoUri
+                }
+                user.updateProfile(profileUpdates).addOnSuccessListener {
+                    val profile = User(uid = uid, displayName = name, photoUrl = photoUri?.toString())
+                    Firebase.firestore.collection("users").document(uid).set(profile)
+                }
+            }
+
+            val localImage = imageUri
+            if (localImage != null) {
+                storageRef.putFile(localImage).continueWithTask { task ->
+                    if (!task.isSuccessful) {
+                        throw task.exception ?: Exception("Upload failed")
+                    }
+                    storageRef.downloadUrl
+                }.addOnSuccessListener { downloadUri ->
+                    updateProfile(downloadUri)
+                }
+            } else {
+                updateProfile(user.photoUrl)
+            }
+        }
+
+        buttonLogout.setOnClickListener {
             FirebaseAuth.getInstance().signOut()
             startActivity(Intent(requireContext(), LoginActivity::class.java))
             requireActivity().finish()

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -2,48 +2,65 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:padding="16dp">
 
-    <TextView
-        android:id="@+id/textProfile"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Perfil"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
+    <ImageView
+        android:id="@+id/imageProfile"
+        android:layout_width="120dp"
+        android:layout_height="120dp"
+        android:src="@drawable/ic_person"
+        android:contentDescription="@string/profile_photo"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toTopOf="@id/textUserName"
-        app:layout_constraintVertical_chainStyle="packed" />
-
-    <TextView
-        android:id="@+id/textUserName"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Nombre:"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/textProfile"
-        app:layout_constraintBottom_toTopOf="@id/textUserEmail" />
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/nameLayout"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        app:layout_constraintTop_toBottomOf="@id/imageProfile"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/editDisplayName"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/display_name" />
+    </com.google.android.material.textfield.TextInputLayout>
 
     <TextView
         android:id="@+id/textUserEmail"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Correo:"
+        android:layout_marginTop="16dp"
+        app:layout_constraintTop_toBottomOf="@id/nameLayout"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/textUserName"
-        app:layout_constraintBottom_toTopOf="@id/buttonLogout" />
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/buttonSave"
+        style="@style/AppButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/save"
+        app:layout_constraintTop_toBottomOf="@id/textUserEmail"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/buttonLogout"
         style="@style/AppButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
         android:text="@string/logout"
+        app:layout_constraintTop_toBottomOf="@id/buttonSave"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/textUserEmail"
-        app:layout_constraintBottom_toBottomOf="parent" />
+        app:layout_constraintEnd_toEndOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,9 @@
     <string name="error_generic">Error</string>
     <string name="required_field">Campo requerido</string>
     <string name="logout">Cerrar sesión</string>
+    <string name="save">Guardar</string>
+    <string name="display_name">Nombre</string>
+    <string name="profile_photo">Foto de perfil</string>
     <string name="chats_title">Chats</string>
     <string name="error_invalid_user">Usuario no registrado</string>
     <string name="error_invalid_credentials">Credenciales incorrectas</string>


### PR DESCRIPTION
## Summary
- redesign profile screen with photo, editable name, save and logout buttons
- allow selecting profile image and saving name/photo to Firebase Auth & Firestore
- load profile pictures using Glide

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c4699d54248320b4a188aa8ff2f181