### PR TITLE
Track user online presence and display status indicators

### DIFF
--- a/app/src/main/java/com/example/projectandroid/model/User.kt
+++ b/app/src/main/java/com/example/projectandroid/model/User.kt
@@ -7,4 +7,5 @@ data class User(
     val uid: String = "",
     val displayName: String = "",
     val photoUrl: String? = null,
+    val isOnline: Boolean = false,
 )

--- a/app/src/main/java/com/example/projectandroid/ui/ChatListAdapter.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/ChatListAdapter.kt
@@ -9,6 +9,8 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.example.projectandroid.R
 import com.example.projectandroid.model.ChatRoom
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
 
 class ChatListAdapter(
     private val onClick: (ChatRoom) -> Unit,
@@ -17,6 +19,7 @@ class ChatListAdapter(
     class ChatRoomViewHolder(view: View) : RecyclerView.ViewHolder(view) {
         val nameText: TextView = view.findViewById(R.id.textName)
         val lastMessageText: TextView = view.findViewById(R.id.textLastMessage)
+        val statusView: View = view.findViewById(R.id.viewStatus)
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ChatRoomViewHolder {
@@ -32,6 +35,12 @@ class ChatListAdapter(
             text = room.lastMessage
             visibility = View.VISIBLE
         }
+        holder.statusView.setBackgroundResource(R.drawable.offline_indicator)
+        Firebase.firestore.collection("users").document(room.contactUid).get()
+            .addOnSuccessListener { snapshot ->
+                val online = snapshot.getBoolean("isOnline") == true
+                holder.statusView.setBackgroundResource(if (online) R.drawable.online_indicator else R.drawable.offline_indicator)
+            }
         holder.itemView.setOnClickListener { onClick(room) }
     }
 

--- a/app/src/main/java/com/example/projectandroid/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/MainActivity.kt
@@ -5,6 +5,9 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import com.example.projectandroid.R
 import com.google.android.material.bottomnavigation.BottomNavigationView
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -33,6 +36,21 @@ class MainActivity : AppCompatActivity() {
                 else -> false
             }
         }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        setOnlineStatus(true)
+    }
+
+    override fun onStop() {
+        setOnlineStatus(false)
+        super.onStop()
+    }
+
+    private fun setOnlineStatus(online: Boolean) {
+        val uid = FirebaseAuth.getInstance().currentUser?.uid ?: return
+        Firebase.firestore.collection("users").document(uid).update("isOnline", online)
     }
 
     private fun replaceFragment(fragment: Fragment) {

--- a/app/src/main/java/com/example/projectandroid/ui/ProfileFragment.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/ProfileFragment.kt
@@ -68,7 +68,7 @@ class ProfileFragment : Fragment() {
                     this.photoUri = photoUri
                 }
                 user.updateProfile(profileUpdates).addOnSuccessListener {
-                    val profile = User(uid = uid, displayName = name, photoUrl = photoUri?.toString())
+                    val profile = User(uid = uid, displayName = name, photoUrl = photoUri?.toString(), isOnline = true)
                     Firebase.firestore.collection("users").document(uid).set(profile)
                 }
             }

--- a/app/src/main/java/com/example/projectandroid/ui/RegisterActivity.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/RegisterActivity.kt
@@ -69,6 +69,7 @@ class RegisterActivity : AppCompatActivity() {
             uid = user.uid,
             displayName = name,
             photoUrl = user.photoUrl?.toString(),
+            isOnline = true,
           )
 
           Firebase.firestore.collection("users").document(user.uid).set(profile)

--- a/app/src/main/java/com/example/projectandroid/ui/UserAdapter.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/UserAdapter.kt
@@ -16,6 +16,7 @@ class UserAdapter(
 
     class UserViewHolder(view: View) : RecyclerView.ViewHolder(view) {
         val nameText: TextView = view.findViewById(R.id.textName)
+        val statusView: View = view.findViewById(R.id.viewStatus)
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): UserViewHolder {
@@ -27,6 +28,9 @@ class UserAdapter(
     override fun onBindViewHolder(holder: UserViewHolder, position: Int) {
         val user = getItem(position)
         holder.nameText.text = user.displayName
+        holder.statusView.setBackgroundResource(
+            if (user.isOnline) R.drawable.online_indicator else R.drawable.offline_indicator
+        )
         holder.itemView.setOnClickListener { onClick(user) }
     }
 

--- a/app/src/main/res/drawable/offline_indicator.xml
+++ b/app/src/main/res/drawable/offline_indicator.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="oval">
+    <solid android:color="#F44336" />
+</shape>

--- a/app/src/main/res/drawable/online_indicator.xml
+++ b/app/src/main/res/drawable/online_indicator.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="oval">
+    <solid android:color="#4CAF50" />
+</shape>

--- a/app/src/main/res/layout/item_user.xml
+++ b/app/src/main/res/layout/item_user.xml
@@ -5,13 +5,25 @@
     android:orientation="horizontal"
     android:padding="16dp">
 
-    <ImageView
-        android:id="@+id/imageAvatar"
+    <FrameLayout
         android:layout_width="40dp"
         android:layout_height="40dp"
-        android:layout_marginEnd="16dp"
-        android:src="@mipmap/ic_launcher"
-        android:contentDescription="@null" />
+        android:layout_marginEnd="16dp">
+
+        <ImageView
+            android:id="@+id/imageAvatar"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:src="@mipmap/ic_launcher"
+            android:contentDescription="@null" />
+
+        <View
+            android:id="@+id/viewStatus"
+            android:layout_width="10dp"
+            android:layout_height="10dp"
+            android:layout_gravity="bottom|end"
+            android:background="@drawable/offline_indicator" />
+    </FrameLayout>
 
     <LinearLayout
         android:layout_width="0dp"


### PR DESCRIPTION
## Summary
- add `isOnline` property to `User` and set status on registration/profile updates
- update `MainActivity` to toggle online presence in Firestore
- show green/red indicators in user and chat lists

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c46a8a822c8320add4c5cbde326929