### PR TITLE
chore: migrate to material3 dynamic colors

### DIFF
--- a/app/src/main/java/com/example/projectandroid/ProjectApplication.kt
+++ b/app/src/main/java/com/example/projectandroid/ProjectApplication.kt
@@ -2,10 +2,13 @@ package com.example.projectandroid
 
 import android.app.Application
 import com.example.projectandroid.util.AppLogger
+import com.google.android.material.color.DynamicColors
 
 class ProjectApplication : Application() {
   override fun onCreate() {
     super.onCreate()
+
+    DynamicColors.applyToActivitiesIfAvailable(this)
 
     val defaultHandler = Thread.getDefaultUncaughtExceptionHandler()
     Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -45,8 +45,8 @@
                 android:layout_height="wrap_content"
                 android:hint="Email"
                 android:inputType="textEmailAddress"
-                android:textColor="@color/md_theme_light_onSecondaryContainer"
-                android:textColorHint="@color/md_theme_light_secondary" />
+                android:textColor="?attr/colorOnSecondaryContainer"
+                android:textColorHint="?attr/colorSecondary" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
@@ -66,8 +66,8 @@
                 android:layout_height="wrap_content"
                 android:hint="Password"
                 android:inputType="textPassword"
-                android:textColor="@color/md_theme_light_onSecondaryContainer"
-                android:textColorHint="@color/md_theme_light_secondary" />
+                android:textColor="?attr/colorOnSecondaryContainer"
+                android:textColorHint="?attr/colorSecondary" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.button.MaterialButton

--- a/app/src/main/res/layout/activity_register.xml
+++ b/app/src/main/res/layout/activity_register.xml
@@ -39,8 +39,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:hint="Name"
-                android:textColor="@color/md_theme_light_onSecondaryContainer"
-                android:textColorHint="@color/md_theme_light_secondary" />
+                android:textColor="?attr/colorOnSecondaryContainer"
+                android:textColorHint="?attr/colorSecondary" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
@@ -60,8 +60,8 @@
                 android:layout_height="wrap_content"
                 android:hint="Email"
                 android:inputType="textEmailAddress"
-                android:textColor="@color/md_theme_light_onSecondaryContainer"
-                android:textColorHint="@color/md_theme_light_secondary" />
+                android:textColor="?attr/colorOnSecondaryContainer"
+                android:textColorHint="?attr/colorSecondary" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
@@ -81,8 +81,8 @@
                 android:layout_height="wrap_content"
                 android:hint="Password"
                 android:inputType="textPassword"
-                android:textColor="@color/md_theme_light_onSecondaryContainer"
-                android:textColorHint="@color/md_theme_light_secondary" />
+                android:textColor="?attr/colorOnSecondaryContainer"
+                android:textColorHint="?attr/colorSecondary" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.button.MaterialButton

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Tema base (night) con Material Components -->
-    <style name="Base.Theme.ProjectAndroid" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+    <!-- Tema base (night) con Material 3 -->
+    <style name="Base.Theme.ProjectAndroid" parent="Theme.Material3.DayNight.NoActionBar">
         <!-- Opcional: personaliza colores para modo oscuro -->
         <!-- <item name="colorPrimary">@color/md_theme_dark_primary</item> -->
         <!-- <item name="colorSecondary">@color/md_theme_dark_secondary</item> -->

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -2,12 +2,7 @@
 <resources>
     <color name="md_theme_light_primary">#6750A4</color>
     <color name="md_theme_light_onPrimary">#FFFFFF</color>
-    <color name="md_theme_light_primaryContainer">#EADDFF</color>
-    <color name="md_theme_light_onPrimaryContainer">#21005D</color>
     <color name="md_theme_light_secondary">#625B71</color>
-    <color name="md_theme_light_onSecondary">#FFFFFF</color>
-    <color name="md_theme_light_secondaryContainer">#E8DEF8</color>
-    <color name="md_theme_light_onSecondaryContainer">#1D192B</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -5,8 +5,8 @@
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_marginTop">16dp</item>
         <item name="android:padding">16dp</item>
-        <item name="android:textColor">@color/md_theme_light_onSecondaryContainer</item>
-        <item name="android:textColorHint">@color/md_theme_light_secondary</item>
+        <item name="android:textColor">?attr/colorOnSecondaryContainer</item>
+        <item name="android:textColorHint">?attr/colorSecondary</item>
     </style>
 
     <style name="AppButton" parent="Widget.MaterialComponents.Button">
@@ -15,7 +15,7 @@
         <item name="android:layout_marginTop">16dp</item>
         <item name="android:padding">16dp</item>
         <item name="android:backgroundTint">?attr/colorPrimary</item>
-        <item name="android:textColor">@android:color/white</item>
+        <item name="android:textColor">?attr/colorOnPrimary</item>
         <item name="cornerRadius">8dp</item>
     </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <!-- Base application theme (Material Components) -->
-    <style name="Base.Theme.ProjectAndroid" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+    <!-- Base application theme using Material 3 -->
+    <style name="Base.Theme.ProjectAndroid" parent="Theme.Material3.DayNight.NoActionBar">
         <!-- Colores principales de tu app -->
         <item name="colorPrimary">@color/md_theme_light_primary</item>
         <item name="colorSecondary">@color/md_theme_light_secondary</item>
 
         <!-- Contraste sobre colorPrimary (botones/toolbar) -->
-        <item name="colorOnPrimary">@android:color/white</item>
+        <item name="colorOnPrimary">@color/md_theme_light_onPrimary</item>
     </style>
 
     <!-- Tema de la app -->


### PR DESCRIPTION
## Summary
- switch app themes to Material3 DayNight
- replace hardcoded color resources with Material3 attributes
- enable Material You dynamic colors and trim fallback palette

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c46ecd62108320a8548aa42569ff9d