### PR TITLE
refactor: migrate toolbar and search components

### DIFF
--- a/app/src/main/java/com/example/projectandroid/ui/ChatListFragment.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/ChatListFragment.kt
@@ -22,14 +22,15 @@ import com.example.projectandroid.util.ErrorLogger
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
-import androidx.appcompat.widget.SearchView
-import androidx.appcompat.widget.Toolbar
+import androidx.core.widget.addTextChangedListener
+import com.google.android.material.appbar.MaterialToolbar
+import com.google.android.material.textfield.TextInputEditText
 import java.util.Locale
 
 class ChatListFragment : Fragment() {
     private val viewModel: ChatListViewModel by viewModels()
     private lateinit var adapter: ChatListAdapter
-    private lateinit var searchView: SearchView
+    private lateinit var searchInput: TextInputEditText
     private var allRooms: List<ChatRoom> = emptyList()
 
     override fun onCreateView(
@@ -45,7 +46,7 @@ class ChatListFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         val currentUser = Firebase.auth.currentUser!!
-        val toolbar = view.findViewById<Toolbar>(R.id.topAppBar)
+        val toolbar = view.findViewById<MaterialToolbar>(R.id.topAppBar)
         (requireActivity() as androidx.appcompat.app.AppCompatActivity).setSupportActionBar(toolbar)
 
         adapter = ChatListAdapter { room ->
@@ -71,14 +72,10 @@ class ChatListFragment : Fragment() {
         recycler.adapter = adapter
         recycler.addItemDecoration(DividerItemDecoration(requireContext(), DividerItemDecoration.VERTICAL))
 
-        searchView = view.findViewById(R.id.searchView)
-        searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
-            override fun onQueryTextSubmit(query: String?): Boolean = false
-            override fun onQueryTextChange(newText: String?): Boolean {
-                filterRooms(newText ?: "")
-                return true
-            }
-        })
+        searchInput = view.findViewById<TextInputEditText>(R.id.editSearch)
+        searchInput.addTextChangedListener { text ->
+            filterRooms(text?.toString() ?: "")
+        }
 
         viewModel.loading.observe(viewLifecycleOwner) { isLoading ->
             progressBar.visibility = if (isLoading) View.VISIBLE else View.GONE
@@ -91,7 +88,7 @@ class ChatListFragment : Fragment() {
             } else {
                 placeholder.visibility = View.GONE
                 recycler.visibility = View.VISIBLE
-                filterRooms(searchView.query.toString())
+                filterRooms(searchInput.text?.toString() ?: "")
             }
         }
         viewModel.error.observe(viewLifecycleOwner) { e ->

--- a/app/src/main/java/com/example/projectandroid/ui/LoginActivity.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/LoginActivity.kt
@@ -9,7 +9,7 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.example.projectandroid.R
 import com.example.projectandroid.util.AppLogger
-import androidx.appcompat.widget.Toolbar
+import com.google.android.material.appbar.MaterialToolbar
 import android.widget.Button
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
@@ -31,7 +31,7 @@ class LoginActivity : AppCompatActivity() {
 
     setContentView(R.layout.activity_login)
 
-    val toolbar = findViewById<Toolbar>(R.id.topAppBar)
+    val toolbar = findViewById<MaterialToolbar>(R.id.topAppBar)
     setSupportActionBar(toolbar)
     supportActionBar?.title = getString(R.string.login_title)
 

--- a/app/src/main/java/com/example/projectandroid/ui/RegisterActivity.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/RegisterActivity.kt
@@ -8,7 +8,7 @@ import androidx.appcompat.app.AppCompatActivity
 import com.example.projectandroid.R
 import com.example.projectandroid.model.User
 import com.example.projectandroid.util.AppLogger
-import androidx.appcompat.widget.Toolbar
+import com.google.android.material.appbar.MaterialToolbar
 import android.widget.Button
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
@@ -22,7 +22,7 @@ class RegisterActivity : AppCompatActivity() {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_register)
 
-    val toolbar = findViewById<Toolbar>(R.id.topAppBar)
+    val toolbar = findViewById<MaterialToolbar>(R.id.topAppBar)
     setSupportActionBar(toolbar)
     supportActionBar?.setDisplayHomeAsUpEnabled(true)
 

--- a/app/src/main/java/com/example/projectandroid/ui/SearchUserFragment.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/SearchUserFragment.kt
@@ -8,8 +8,9 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import androidx.appcompat.widget.SearchView
-import androidx.appcompat.widget.Toolbar
+import androidx.core.widget.addTextChangedListener
+import com.google.android.material.appbar.MaterialToolbar
+import com.google.android.material.textfield.TextInputEditText
 import com.example.projectandroid.R
 import com.example.projectandroid.repository.UserRepository
 import com.example.projectandroid.util.AppLogger
@@ -39,7 +40,7 @@ class SearchUserFragment : Fragment() {
             return
         }
 
-        val toolbar = view.findViewById<Toolbar>(R.id.topAppBar)
+        val toolbar = view.findViewById<MaterialToolbar>(R.id.topAppBar)
         (requireActivity() as androidx.appcompat.app.AppCompatActivity).setSupportActionBar(toolbar)
 
         adapter = UserAdapter { user ->
@@ -61,22 +62,18 @@ class SearchUserFragment : Fragment() {
         recycler.layoutManager = LinearLayoutManager(requireContext())
         recycler.adapter = adapter
 
-        val searchView = view.findViewById<SearchView>(R.id.searchView)
-        searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
-            override fun onQueryTextSubmit(query: String?): Boolean = false
-            override fun onQueryTextChange(newText: String?): Boolean {
-                val q = newText ?: ""
-                if (q.isBlank()) {
-                    adapter.submitList(emptyList())
-                } else {
-                    userRepository.getUsersByDisplayName(q, onSuccess = { users ->
-                        adapter.submitList(users)
-                    }, onFailure = { e ->
-                        AppLogger.logError(requireContext(), e)
-                    })
-                }
-                return true
+        val searchInput = view.findViewById<TextInputEditText>(R.id.editSearch)
+        searchInput.addTextChangedListener { text ->
+            val q = text?.toString() ?: ""
+            if (q.isBlank()) {
+                adapter.submitList(emptyList())
+            } else {
+                userRepository.getUsersByDisplayName(q, onSuccess = { users ->
+                    adapter.submitList(users)
+                }, onFailure = { e ->
+                    AppLogger.logError(requireContext(), e)
+                })
             }
-        })
+        }
     }
 }

--- a/app/src/main/res/layout/activity_chat.xml
+++ b/app/src/main/res/layout/activity_chat.xml
@@ -12,6 +12,7 @@
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/topAppBar"
+            style="@style/AppToolbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="?attr/colorPrimary"

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -20,12 +20,13 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent">
 
-            <androidx.appcompat.widget.Toolbar
+            <com.google.android.material.appbar.MaterialToolbar
                 android:id="@+id/topAppBar"
+                style="@style/AppToolbar"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:background="?attr/colorPrimary"
-                android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
+                android:theme="@style/ThemeOverlay.Material3.Dark.ActionBar" />
         </com.google.android.material.appbar.AppBarLayout>
 
         <com.google.android.material.textfield.TextInputLayout

--- a/app/src/main/res/layout/activity_register.xml
+++ b/app/src/main/res/layout/activity_register.xml
@@ -12,12 +12,13 @@
         android:padding="16dp"
         android:fitsSystemWindows="true">
 
-        <androidx.appcompat.widget.Toolbar
+        <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/topAppBar"
+            style="@style/AppToolbar"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:background="?attr/colorPrimary"
-            android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+            android:theme="@style/ThemeOverlay.Material3.Dark.ActionBar"
             app:title="@string/register_title"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/fragment_chat_list.xml
+++ b/app/src/main/res/layout/fragment_chat_list.xml
@@ -5,27 +5,37 @@
     android:layout_height="match_parent"
     android:fitsSystemWindows="true">
 
-    <androidx.appcompat.widget.Toolbar
+    <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/topAppBar"
+        style="@style/AppToolbar"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:background="?attr/colorPrimary"
-        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+        android:theme="@style/ThemeOverlay.Material3.Dark.ActionBar"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:title="@string/chats_title" />
 
-    <androidx.appcompat.widget.SearchView
-        android:id="@+id/searchView"
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/searchLayout"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginTop="8dp"
         android:layout_marginEnd="16dp"
+        app:startIconDrawable="@drawable/ic_search"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/topAppBar" />
+        app:layout_constraintTop_toBottomOf="@id/topAppBar">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/editSearch"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/search_hint" />
+
+    </com.google.android.material.textfield.TextInputLayout>
 
     <FrameLayout
         android:id="@+id/contentContainer"
@@ -38,7 +48,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/searchView">
+        app:layout_constraintTop_toBottomOf="@id/searchLayout">
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/recyclerChats"

--- a/app/src/main/res/layout/fragment_search_user.xml
+++ b/app/src/main/res/layout/fragment_search_user.xml
@@ -5,27 +5,37 @@
     android:layout_height="match_parent"
     android:fitsSystemWindows="true">
 
-    <androidx.appcompat.widget.Toolbar
+    <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/topAppBar"
+        style="@style/AppToolbar"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:background="?attr/colorPrimary"
-        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+        android:theme="@style/ThemeOverlay.Material3.Dark.ActionBar"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:title="@string/search_user_title" />
 
-    <androidx.appcompat.widget.SearchView
-        android:id="@+id/searchView"
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/searchLayout"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginTop="8dp"
         android:layout_marginEnd="16dp"
+        app:startIconDrawable="@drawable/ic_search"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/topAppBar" />
+        app:layout_constraintTop_toBottomOf="@id/topAppBar">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/editSearch"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/search_hint" />
+
+    </com.google.android.material.textfield.TextInputLayout>
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerUsers"
@@ -38,6 +48,6 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/searchView" />
+        app:layout_constraintTop_toBottomOf="@id/searchLayout" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,4 +18,5 @@
     <string name="login_title">Iniciar sesión</string>
     <string name="register_title">Registro</string>
     <string name="search_user_title">Buscar usuario</string>
+    <string name="search_hint">Buscar</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -18,4 +18,6 @@
         <item name="android:textColor">?attr/colorOnPrimary</item>
         <item name="cornerRadius">8dp</item>
     </style>
+
+    <style name="AppToolbar" parent="Widget.Material3.Toolbar" />
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -9,6 +9,7 @@
 
         <!-- Contraste sobre colorPrimary (botones/toolbar) -->
         <item name="colorOnPrimary">@color/md_theme_light_onPrimary</item>
+        <item name="toolbarStyle">@style/AppToolbar</item>
     </style>
 
     <!-- Tema de la app -->


### PR DESCRIPTION
## Summary
- Replace AppCompat Toolbar with MaterialToolbar across login, register, chat list and search user screens.
- Swap legacy SearchView for TextInputLayout and TextInputEditText with search icon; update fragments to filter via text listeners.
- Add AppToolbar style inheriting from Widget.Material3.Toolbar and wire it through the app theme.

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c47603a1188320827223ac28afe704