### PR TITLE
feat: add themed chat bubble drawables

### DIFF
--- a/app/src/main/java/com/example/projectandroid/ui/ChatAdapter.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/ChatAdapter.kt
@@ -52,10 +52,10 @@ class ChatAdapter(
 
         if (message.senderId == myUid) {
             holder.root.gravity = Gravity.END
-            holder.messageText.setBackgroundResource(R.drawable.bg_bubble_me)
+            holder.messageText.setBackgroundResource(R.drawable.bubble_outgoing)
         } else {
             holder.root.gravity = Gravity.START
-            holder.messageText.setBackgroundResource(R.drawable.bg_bubble_other)
+            holder.messageText.setBackgroundResource(R.drawable.bubble_incoming)
         }
     }*/
 
@@ -77,18 +77,18 @@ class ChatAdapter(
         if (message.senderId == myUid) {
             holder.root.gravity = Gravity.END
             if (holder.messageText.visibility == View.VISIBLE) {
-                holder.messageText.setBackgroundResource(R.drawable.bg_bubble_me)
+                holder.messageText.setBackgroundResource(R.drawable.bubble_outgoing)
             }
             if (holder.imageView.visibility == View.VISIBLE) {
-                holder.imageView.setBackgroundResource(R.drawable.bg_bubble_me)
+                holder.imageView.setBackgroundResource(R.drawable.bubble_outgoing)
             }
         } else {
             holder.root.gravity = Gravity.START
             if (holder.messageText.visibility == View.VISIBLE) {
-                holder.messageText.setBackgroundResource(R.drawable.bg_bubble_other)
+                holder.messageText.setBackgroundResource(R.drawable.bubble_incoming)
             }
             if (holder.imageView.visibility == View.VISIBLE) {
-                holder.imageView.setBackgroundResource(R.drawable.bg_bubble_other)
+                holder.imageView.setBackgroundResource(R.drawable.bubble_incoming)
             }
         }
 

--- a/app/src/main/res/drawable/bg_bubble_me.xml
+++ b/app/src/main/res/drawable/bg_bubble_me.xml
@@ -1,4 +1,0 @@
-<shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <solid android:color="#DCF8C6"/>
-    <corners android:radius="16dp"/>
-</shape>

--- a/app/src/main/res/drawable/bg_bubble_other.xml
+++ b/app/src/main/res/drawable/bg_bubble_other.xml
@@ -1,5 +1,0 @@
-<shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <solid android:color="#FFFFFF"/>
-    <corners android:radius="16dp"/>
-    <stroke android:width="1dp" android:color="#E0E0E0"/>
-</shape>

--- a/app/src/main/res/drawable/shape/bubble_incoming.xml
+++ b/app/src/main/res/drawable/shape/bubble_incoming.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.shape.MaterialShapeDrawable xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:tint="?attr/colorSurfaceVariant"
+    app:cornerFamily="rounded"
+    app:cornerSizeTopStart="16dp"
+    app:cornerSizeTopEnd="16dp"
+    app:cornerSizeBottomStart="0dp"
+    app:cornerSizeBottomEnd="16dp" />

--- a/app/src/main/res/drawable/shape/bubble_outgoing.xml
+++ b/app/src/main/res/drawable/shape/bubble_outgoing.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.shape.MaterialShapeDrawable xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:tint="?attr/colorPrimaryContainer"
+    app:cornerFamily="rounded"
+    app:cornerSizeTopStart="16dp"
+    app:cornerSizeTopEnd="16dp"
+    app:cornerSizeBottomStart="16dp"
+    app:cornerSizeBottomEnd="0dp" />

--- a/app/src/main/res/layout/item_message.xml
+++ b/app/src/main/res/layout/item_message.xml
@@ -13,7 +13,8 @@
         android:layout_height="wrap_content"
         android:padding="8dp"
         android:textColor="@android:color/black"
-        android:background="@drawable/bg_bubble_other" />
+        android:background="@drawable/bubble_incoming"
+        android:foreground="?attr/selectableItemBackgroundBorderless" />
 
     <ImageView
             android:id="@+id/imageMessage"
@@ -22,7 +23,9 @@
             android:scaleType="centerCrop"
             android:adjustViewBounds="true"
             android:layout_marginTop="4dp"
-            android:visibility="gone" />
+            android:visibility="gone"
+            android:background="@drawable/bubble_incoming"
+            android:foreground="?attr/selectableItemBackgroundBorderless" />
 
 
     <TextView


### PR DESCRIPTION
## Summary
- replace chat bubble backgrounds with MaterialShapeDrawables using theme colors
- add ripple foregrounds to message items and support outgoing/incoming bubbles

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden" )*

------
https://chatgpt.com/codex/tasks/task_e_68c47ab0a7808320846c1becd0e1c50c