### PR TITLE
Refine app colors and theme

### DIFF
--- a/app/src/main/res/color/bottom_nav_colors.xml
+++ b/app/src/main/res/color/bottom_nav_colors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_checked="true" android:color="?attr/colorPrimary" />
+    <item android:state_checked="true" android:color="@color/md_theme_light_primary" />
     <item android:state_checked="false" android:color="?attr/colorOnSurfaceVariant" />
 </selector>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="md_theme_light_primary">#388E3C</color>
+    <color name="md_theme_light_onPrimary">#FFFFFF</color>
+    <color name="md_theme_light_secondary">#0288D1</color>
+</resources>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -2,10 +2,9 @@
 <resources>
     <!-- Tema base (night) con Material 3 -->
     <style name="Base.Theme.ProjectAndroid" parent="Theme.Material3.DayNight.NoActionBar">
-        <!-- Opcional: personaliza colores para modo oscuro -->
-        <!-- <item name="colorPrimary">@color/md_theme_dark_primary</item> -->
-        <!-- <item name="colorSecondary">@color/md_theme_dark_secondary</item> -->
-        <!-- <item name="colorOnPrimary">@android:color/white</item> -->
+        <item name="colorPrimary">@color/md_theme_light_primary</item>
+        <item name="colorSecondary">@color/md_theme_light_secondary</item>
+        <item name="colorOnPrimary">@color/md_theme_light_onPrimary</item>
     </style>
 
     <!-- Alias del tema de la app (igual que en values/) -->

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="md_theme_light_primary">#6750A4</color>
+    <color name="md_theme_light_primary">#4CAF50</color>
     <color name="md_theme_light_onPrimary">#FFFFFF</color>
-    <color name="md_theme_light_secondary">#625B71</color>
+    <color name="md_theme_light_secondary">#03A9F4</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
 </resources>


### PR DESCRIPTION
## Summary
- soften light theme primary and secondary colors
- add night palette and hook it into theme
- update bottom navigation selector for new primary hue

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c48b7a0c5c83208511fd9406bd65ee