### PR TITLE
feat(theme): expand Material 3 color support

### DIFF
--- a/app/src/main/java/com/example/projectandroid/ProjectApplication.kt
+++ b/app/src/main/java/com/example/projectandroid/ProjectApplication.kt
@@ -3,12 +3,15 @@ package com.example.projectandroid
 import android.app.Application
 import com.example.projectandroid.util.AppLogger
 import com.google.android.material.color.DynamicColors
+import android.os.Build
 
 class ProjectApplication : Application() {
   override fun onCreate() {
     super.onCreate()
 
-    DynamicColors.applyToActivitiesIfAvailable(this)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+      DynamicColors.applyToActivitiesIfAvailable(this)
+    }
 
     val defaultHandler = Thread.getDefaultUncaughtExceptionHandler()
     Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -18,6 +18,8 @@
           android:background="?attr/colorSurface"
           app:menu="@menu/menu_bottom_nav"
           app:itemIconTint="@color/bottom_nav_colors"
-          app:itemTextColor="@color/bottom_nav_colors" />
+          app:itemTextColor="@color/bottom_nav_colors"
+          app:itemRippleColor="?attr/colorTertiary"
+          app:labelVisibilityMode="labeled" />
 
 </LinearLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,6 +3,9 @@
     <color name="md_theme_light_primary">#4CAF50</color>
     <color name="md_theme_light_onPrimary">#FFFFFF</color>
     <color name="md_theme_light_secondary">#03A9F4</color>
+    <color name="md_theme_light_tertiary">#FF9800</color>
+    <color name="md_theme_light_surfaceVariant">#E7E0EC</color>
+    <color name="md_theme_light_onSurface">#1C1B1F</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -5,8 +5,9 @@
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_marginTop">16dp</item>
         <item name="android:padding">16dp</item>
-        <item name="android:textColor">?attr/colorOnSecondaryContainer</item>
-        <item name="android:textColorHint">?attr/colorSecondary</item>
+        <item name="android:backgroundTint">?attr/colorSurfaceVariant</item>
+        <item name="android:textColor">?attr/colorOnSurface</item>
+        <item name="android:textColorHint">?attr/colorTertiary</item>
     </style>
 
     <style name="AppButton" parent="Widget.Material3.Button">

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -6,6 +6,9 @@
         <!-- Colores principales de tu app -->
         <item name="colorPrimary">@color/md_theme_light_primary</item>
         <item name="colorSecondary">@color/md_theme_light_secondary</item>
+        <item name="colorTertiary">@color/md_theme_light_tertiary</item>
+        <item name="colorSurfaceVariant">@color/md_theme_light_surfaceVariant</item>
+        <item name="colorOnSurface">@color/md_theme_light_onSurface</item>
 
         <!-- Contraste sobre colorPrimary (botones/toolbar) -->
         <item name="colorOnPrimary">@color/md_theme_light_onPrimary</item>


### PR DESCRIPTION
## Summary
- add tertiary, surfaceVariant and onSurface colors to theme
- update custom styles and navigation bar to use new colors
- apply DynamicColors on Android 12+ in application

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c48eb74d28832084b69365b5afe78d