### PR TITLE
Add about and phone fields to user profile

### DIFF
--- a/app/src/main/java/com/example/projectandroid/model/User.kt
+++ b/app/src/main/java/com/example/projectandroid/model/User.kt
@@ -8,4 +8,6 @@ data class User(
     val displayName: String = "",
     val photoUrl: String? = null,
     val isOnline: Boolean = false,
+    val about: String = "",
+    val phone: String = "",
 )

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -91,49 +91,37 @@
                 </androidx.constraintlayout.widget.ConstraintLayout>
             </com.google.android.material.card.MaterialCardView>
 
-            <com.google.android.material.card.MaterialCardView
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/aboutLayout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="16dp"
-                app:cardElevation="2dp">
+                android:layout_marginBottom="16dp">
 
-                <LinearLayout
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/editAbout"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:padding="16dp">
+                    android:hint="@string/profile_about"
+                    android:inputType="textMultiLine"
+                    android:minLines="3"
+                    android:gravity="top|start" />
 
-                    <com.google.android.material.textview.MaterialTextView
-                        android:id="@+id/sectionAbout"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/profile_about"
-                        style="?attr/textAppearanceTitleMedium" />
+            </com.google.android.material.textfield.TextInputLayout>
 
-                </LinearLayout>
-            </com.google.android.material.card.MaterialCardView>
-
-            <com.google.android.material.card.MaterialCardView
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/phoneLayout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="16dp"
-                app:cardElevation="2dp">
+                android:layout_marginBottom="16dp">
 
-                <LinearLayout
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/editPhone"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:padding="16dp">
+                    android:hint="@string/profile_phone"
+                    android:inputType="phone" />
 
-                    <com.google.android.material.textview.MaterialTextView
-                        android:id="@+id/sectionPhone"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/profile_phone"
-                        style="?attr/textAppearanceTitleMedium" />
-
-                </LinearLayout>
-            </com.google.android.material.card.MaterialCardView>
+            </com.google.android.material.textfield.TextInputLayout>
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/buttonSave"


### PR DESCRIPTION
## Summary
- add `about` and `phone` to `User` model
- replace profile about/phone cards with `TextInputLayout` inputs
- load and save new profile fields in `ProfileFragment`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden" )*

------
https://chatgpt.com/codex/tasks/task_e_68c49c1935608320bad3309279fc141f