### PR TITLE
feat: add password reset and preference sections

### DIFF
--- a/app/src/main/java/com/example/projectandroid/ui/ProfileFragment.kt
+++ b/app/src/main/java/com/example/projectandroid/ui/ProfileFragment.kt
@@ -9,6 +9,7 @@ import android.view.ViewGroup
 import android.widget.Button
 import android.widget.ImageView
 import android.widget.TextView
+import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.Fragment
 import com.bumptech.glide.Glide
@@ -52,6 +53,7 @@ class ProfileFragment : Fragment() {
         val aboutInput = view.findViewById<TextInputEditText>(R.id.editAbout)
         val phoneInput = view.findViewById<TextInputEditText>(R.id.editPhone)
         val buttonSave = view.findViewById<Button>(R.id.buttonSave)
+        val buttonChangePassword = view.findViewById<Button>(R.id.buttonChangePassword)
         val buttonLogout = view.findViewById<Button>(R.id.buttonLogout)
         val buttonEdit = view.findViewById<MaterialButton>(R.id.buttonEdit)
 
@@ -110,6 +112,25 @@ class ProfileFragment : Fragment() {
             } else {
                 updateProfile(user.photoUrl)
             }
+        }
+
+        buttonChangePassword.setOnClickListener {
+            val email = user?.email ?: return@setOnClickListener
+            FirebaseAuth.getInstance().sendPasswordResetEmail(email)
+                .addOnSuccessListener {
+                    Toast.makeText(
+                        requireContext(),
+                        getString(R.string.password_reset_email_sent),
+                        Toast.LENGTH_LONG
+                    ).show()
+                }
+                .addOnFailureListener { e ->
+                    Toast.makeText(
+                        requireContext(),
+                        e.localizedMessage ?: getString(R.string.error_generic),
+                        Toast.LENGTH_LONG
+                    ).show()
+                }
         }
 
         buttonLogout.setOnClickListener {

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -123,6 +123,58 @@
 
             </com.google.android.material.textfield.TextInputLayout>
 
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/cardNotifications"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                app:cardElevation="4dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="16dp">
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/notifications" />
+
+                    <com.google.android.material.materialswitch.MaterialSwitch
+                        android:id="@+id/switchNotifications"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/enable_notifications" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/cardPrivacy"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                app:cardElevation="4dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="16dp">
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/privacy" />
+
+                    <com.google.android.material.materialswitch.MaterialSwitch
+                        android:id="@+id/switchPrivacy"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/private_account" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/buttonSave"
                 style="@style/AppButton.Tonal"
@@ -130,6 +182,14 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
                 android:text="@string/save" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonChangePassword"
+                style="@style/AppButton.Outlined"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:text="@string/change_password" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/buttonLogout"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,4 +23,10 @@
     <string name="edit">Editar</string>
     <string name="profile_about">Acerca de</string>
     <string name="profile_phone">Teléfono</string>
+    <string name="change_password">Cambiar contraseña</string>
+    <string name="password_reset_email_sent">Correo de restablecimiento enviado</string>
+    <string name="notifications">Notificaciones</string>
+    <string name="enable_notifications">Recibir notificaciones</string>
+    <string name="privacy">Privacidad</string>
+    <string name="private_account">Cuenta privada</string>
 </resources>


### PR DESCRIPTION
## Summary
- add password reset button and listener in profile screen
- include notification and privacy preference sections
- define related string resources

## Testing
- `./gradlew test` (fails: Unable to tunnel through proxy, 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68c49e79d0948320ab8f9c79595f5385