### PR TITLE
chore: refresh theme color palette

### DIFF
--- a/app/src/main/res/color/bottom_nav_colors.xml
+++ b/app/src/main/res/color/bottom_nav_colors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_checked="true" android:color="@color/md_theme_light_primary" />
-    <item android:state_checked="false" android:color="?attr/colorOnSurfaceVariant" />
+    <item android:state_checked="false" android:color="@color/md_theme_light_onSurfaceVariant" />
 </selector>

--- a/app/src/main/res/drawable/offline_indicator.xml
+++ b/app/src/main/res/drawable/offline_indicator.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="oval">
-    <solid android:color="#F44336" />
+    <solid android:color="@color/md_theme_light_error" />
 </shape>

--- a/app/src/main/res/drawable/online_indicator.xml
+++ b/app/src/main/res/drawable/online_indicator.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="oval">
-    <solid android:color="#4CAF50" />
+    <solid android:color="@color/md_theme_light_success" />
 </shape>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="md_theme_light_primary">#388E3C</color>
+    <color name="md_theme_light_primary">#6366F1</color>
+    <color name="md_theme_light_secondary">#22D3EE</color>
+    <color name="md_theme_light_tertiary">#FF6B6B</color>
+    <color name="md_theme_light_surface">#111827</color>
+    <color name="md_theme_light_surfaceVariant">#1E293B</color>
+    <color name="md_theme_light_onSurface">#F1F5F9</color>
+    <color name="md_theme_light_onSurfaceVariant">#9CA3AF</color>
+    <color name="md_theme_light_error">#EF4444</color>
+    <color name="md_theme_light_warning">#F59E0B</color>
+    <color name="md_theme_light_success">#22C55E</color>
     <color name="md_theme_light_onPrimary">#FFFFFF</color>
-    <color name="md_theme_light_secondary">#0288D1</color>
 </resources>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -4,6 +4,12 @@
     <style name="Base.Theme.ProjectAndroid" parent="Theme.Material3.DayNight.NoActionBar">
         <item name="colorPrimary">@color/md_theme_light_primary</item>
         <item name="colorSecondary">@color/md_theme_light_secondary</item>
+        <item name="colorTertiary">@color/md_theme_light_tertiary</item>
+        <item name="colorSurface">@color/md_theme_light_surface</item>
+        <item name="colorSurfaceVariant">@color/md_theme_light_surfaceVariant</item>
+        <item name="colorOnSurface">@color/md_theme_light_onSurface</item>
+        <item name="colorOnSurfaceVariant">@color/md_theme_light_onSurfaceVariant</item>
+        <item name="colorError">@color/md_theme_light_error</item>
         <item name="colorOnPrimary">@color/md_theme_light_onPrimary</item>
     </style>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,11 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="md_theme_light_primary">#4CAF50</color>
+    <color name="md_theme_light_primary">#6366F1</color>
+    <color name="md_theme_light_secondary">#22D3EE</color>
+    <color name="md_theme_light_tertiary">#FF6B6B</color>
+    <color name="md_theme_light_surface">#FFFFFF</color>
+    <color name="md_theme_light_surfaceVariant">#F2F4F8</color>
+    <color name="md_theme_light_onSurface">#0F172A</color>
+    <color name="md_theme_light_onSurfaceVariant">#6B7280</color>
+    <color name="md_theme_light_error">#EF4444</color>
+    <color name="md_theme_light_warning">#F59E0B</color>
+    <color name="md_theme_light_success">#22C55E</color>
     <color name="md_theme_light_onPrimary">#FFFFFF</color>
-    <color name="md_theme_light_secondary">#03A9F4</color>
-    <color name="md_theme_light_tertiary">#FF9800</color>
-    <color name="md_theme_light_surfaceVariant">#E7E0EC</color>
-    <color name="md_theme_light_onSurface">#1C1B1F</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -7,8 +7,11 @@
         <item name="colorPrimary">@color/md_theme_light_primary</item>
         <item name="colorSecondary">@color/md_theme_light_secondary</item>
         <item name="colorTertiary">@color/md_theme_light_tertiary</item>
+        <item name="colorSurface">@color/md_theme_light_surface</item>
         <item name="colorSurfaceVariant">@color/md_theme_light_surfaceVariant</item>
         <item name="colorOnSurface">@color/md_theme_light_onSurface</item>
+        <item name="colorOnSurfaceVariant">@color/md_theme_light_onSurfaceVariant</item>
+        <item name="colorError">@color/md_theme_light_error</item>
 
         <!-- Contraste sobre colorPrimary (botones/toolbar) -->
         <item name="colorOnPrimary">@color/md_theme_light_onPrimary</item>


### PR DESCRIPTION
## Summary
- add light and dark color resources with new palette
- wire themes and navigation selector to updated colors
- replace hardcoded indicator drawables with palette colors

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c4a0b1a788832080d06560cfc4a08b