### PR TITLE
Request notification permission on Android 13

### DIFF
--- a/app/src/main/java/com/example/texty/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/texty/ui/MainActivity.kt
@@ -1,7 +1,16 @@
 package com.example.texty.ui
 
+import android.Manifest
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
 import android.os.Bundle
+import android.provider.Settings
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import com.example.texty.R
 import com.google.android.material.bottomnavigation.BottomNavigationView
@@ -10,9 +19,18 @@ import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 
 class MainActivity : AppCompatActivity() {
+    private val requestPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
+            if (!isGranted) {
+                showPermissionDeniedDialog()
+            }
+        }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        requestNotificationPermissionIfNeeded()
 
         val bottomNav = findViewById<BottomNavigationView>(R.id.bottomNavigation)
         if (savedInstanceState == null) {
@@ -61,5 +79,31 @@ class MainActivity : AppCompatActivity() {
         supportFragmentManager.beginTransaction()
             .replace(R.id.fragmentContainer, fragment)
             .commit()
+    }
+
+    private fun requestNotificationPermissionIfNeeded() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val granted = ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.POST_NOTIFICATIONS
+            ) == PackageManager.PERMISSION_GRANTED
+            if (!granted) {
+                requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+            }
+        }
+    }
+
+    private fun showPermissionDeniedDialog() {
+        AlertDialog.Builder(this)
+            .setTitle(R.string.notifications_permission_denied_title)
+            .setMessage(R.string.notifications_permission_denied_message)
+            .setPositiveButton(R.string.open_settings) { _, _ ->
+                val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                    data = Uri.fromParts("package", packageName, null)
+                }
+                startActivity(intent)
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,4 +30,7 @@
     <string name="privacy">Privacidad</string>
     <string name="private_account">Cuenta privada</string>
     <string name="error_not_friends">Debes ser amigo para chatear</string>
+    <string name="notifications_permission_denied_title">Permiso de notificaciones</string>
+    <string name="notifications_permission_denied_message">Sin este permiso no podremos avisarte de nuevos mensajes. Puedes habilitarlo en ajustes.</string>
+    <string name="open_settings">Abrir ajustes</string>
 </resources>


### PR DESCRIPTION
## Summary
- Request POST_NOTIFICATIONS permission at app start using Activity Result API
- Inform users when permission is denied with dialog linking to settings
- Add localized strings for permission dialog

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c63ca01e6c83208ba698ab2729ecc8