### PR TITLE
Fetch FCM token on login and startup

### DIFF
--- a/app/src/main/java/com/example/texty/MessagingService.kt
+++ b/app/src/main/java/com/example/texty/MessagingService.kt
@@ -12,13 +12,9 @@ import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import com.example.texty.ui.MainActivity // TODO: cambia a tu ChatActivity si aplica
-import com.google.firebase.auth.ktx.auth
-import com.google.firebase.firestore.FieldValue
-import com.google.firebase.firestore.SetOptions
-import com.google.firebase.firestore.ktx.firestore
-import com.google.firebase.ktx.Firebase
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
+import com.example.texty.util.FcmTokenManager
 
 class MessagingService : FirebaseMessagingService() {
 
@@ -80,18 +76,7 @@ class MessagingService : FirebaseMessagingService() {
 
   override fun onNewToken(token: String) {
     super.onNewToken(token)
-    val currentUser = Firebase.auth.currentUser ?: return
-
-    // Guardamos como ARRAY por si el usuario usa múltiples dispositivos
-    Firebase.firestore.collection("users")
-      .document(currentUser.uid)
-      .set(
-        mapOf("fcmTokens" to FieldValue.arrayUnion(token)),
-        SetOptions.merge()
-      )
-      .addOnFailureListener { e ->
-        Log.w(TAG, "Error guardando token FCM", e)
-      }
+    FcmTokenManager.sendTokenToFirestore(token)
   }
 
   // --- Helpers ---

--- a/app/src/main/java/com/example/texty/TextyApplication.kt
+++ b/app/src/main/java/com/example/texty/TextyApplication.kt
@@ -2,8 +2,11 @@ package com.example.texty
 
 import android.app.Application
 import com.example.texty.util.AppLogger
+import com.example.texty.util.FcmTokenManager
 import com.google.android.material.color.DynamicColors
 import android.os.Build
+import com.google.firebase.auth.ktx.auth
+import com.google.firebase.ktx.Firebase
 
 class TextyApplication : Application() {
   override fun onCreate() {
@@ -17,6 +20,10 @@ class TextyApplication : Application() {
     Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
       AppLogger.logError(this@TextyApplication, throwable)
       defaultHandler?.uncaughtException(thread, throwable)
+    }
+
+    if (Firebase.auth.currentUser != null) {
+      FcmTokenManager.refreshTokenWithRetry()
     }
   }
 }

--- a/app/src/main/java/com/example/texty/ui/LoginActivity.kt
+++ b/app/src/main/java/com/example/texty/ui/LoginActivity.kt
@@ -18,6 +18,7 @@ import com.google.firebase.auth.FirebaseAuthInvalidCredentialsException
 import com.google.firebase.auth.FirebaseAuthInvalidUserException
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
+import com.example.texty.util.FcmTokenManager
 
 class LoginActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -70,6 +71,7 @@ class LoginActivity : AppCompatActivity() {
           loginButton.isEnabled = true
         }
         .addOnSuccessListener {
+          FcmTokenManager.refreshTokenWithRetry()
           startActivity(Intent(this, MainActivity::class.java))
           finish()
         }

--- a/app/src/main/java/com/example/texty/util/FcmTokenManager.kt
+++ b/app/src/main/java/com/example/texty/util/FcmTokenManager.kt
@@ -1,0 +1,44 @@
+package com.example.texty.util
+
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import com.google.firebase.auth.ktx.auth
+import com.google.firebase.firestore.FieldValue
+import com.google.firebase.firestore.SetOptions
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
+import com.google.firebase.messaging.FirebaseMessaging
+
+object FcmTokenManager {
+  private const val TAG = "FcmTokenManager"
+
+  fun refreshTokenWithRetry(retry: Int = 3) {
+    FirebaseMessaging.getInstance().token
+      .addOnSuccessListener { token ->
+        sendTokenToFirestore(token, retry)
+      }
+      .addOnFailureListener { e ->
+        Log.w(TAG, "Error obteniendo token FCM", e)
+        if (retry > 0) {
+          Handler(Looper.getMainLooper()).postDelayed({ refreshTokenWithRetry(retry - 1) }, 2000)
+        }
+      }
+  }
+
+  fun sendTokenToFirestore(token: String, retry: Int = 3) {
+    val currentUser = Firebase.auth.currentUser ?: return
+    Firebase.firestore.collection("users")
+      .document(currentUser.uid)
+      .set(
+        mapOf("fcmTokens" to FieldValue.arrayUnion(token)),
+        SetOptions.merge()
+      )
+      .addOnFailureListener { e ->
+        Log.w(TAG, "Error guardando token FCM", e)
+        if (retry > 0) {
+          Handler(Looper.getMainLooper()).postDelayed({ sendTokenToFirestore(token, retry - 1) }, 2000)
+        }
+      }
+  }
+}


### PR DESCRIPTION
## Summary
- Retrieve FCM token on app start and after login, saving it to Firestore with retries
- Centralize token upload logic in FcmTokenManager and reuse in MessagingService

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c63d96ae78832089903a9bb7e7071f