### PR TITLE
Send multicast FCM notifications

### DIFF
--- a/app/src/main/java/com/example/texty/model/User.kt
+++ b/app/src/main/java/com/example/texty/model/User.kt
@@ -11,4 +11,5 @@ data class User(
     val about: String = "",
     val phone: String = "",
     val friends: List<String> = emptyList(),
+    val fcmTokens: List<String> = emptyList(),
 )

--- a/functions/index.js
+++ b/functions/index.js
@@ -15,16 +15,17 @@ exports.sendMessageNotification = functions.firestore
     }
 
     const userDoc = await admin.firestore().collection('users').doc(recipientId).get();
-    const token = userDoc.data()?.fcmToken;
-    if (!token) {
+    const tokens = userDoc.data()?.fcmTokens || [];
+    if (tokens.length === 0) {
       return null;
     }
 
-    return admin.messaging().send({
-      token,
+    return admin.messaging().sendEachForMulticast({
+      tokens,
       notification: {
         title: message.senderName || 'Nuevo mensaje',
         body: message.text || '',
       },
+      android: { priority: 'high' },
     });
   });


### PR DESCRIPTION
## Summary
- deliver message notifications to all of a user's devices via `sendEachForMulticast`
- extend user model with `fcmTokens` list to store multiple device tokens
- confirm messaging service persists new tokens in `fcmTokens`

## Testing
- ⚠️ `npm --prefix functions install` (403 Forbidden fetching dependencies)
- ⚠️ `npm --prefix functions test` (no test script)
- ⚠️ `./gradlew test` (failed to download dependencies due to proxy restrictions)


------
https://chatgpt.com/codex/tasks/task_e_68c6418d04888320986180503a0f12fa