### PR TITLE
Implement encrypted message pipeline with session keys

### DIFF
--- a/app/src/main/java/com/example/texty/model/Message.kt
+++ b/app/src/main/java/com/example/texty/model/Message.kt
@@ -6,9 +6,30 @@ data class Message(
     val id: String = "",
     val senderId: String = "",
     val senderName: String = "",
-    val text: String = "",
-    //val createdAt: Timestamp = Timestamp.now()
     val createdAt: Timestamp? = null,
-    val imageUrl: String? = null,
-    val readBy: List<String> = emptyList()
+    val readBy: List<String> = emptyList(),
+    val messageType: String? = null,
+    val encryption: EncryptionPayload? = null,
+    val decrypted: DecryptedMessage? = null,
+    val decryptionError: Boolean = false,
+    val requiresKeyResync: Boolean = false,
+)
+
+data class EncryptionPayload(
+    val ciphertext: String = "",
+    val nonce: String = "",
+    val salt: String = "",
+    val schemeVersion: Int = 1,
+    val encryptionTarget: String = "",
+)
+
+data class DecryptedMessage(
+    val body: MessageBody,
+    val displayText: String,
+)
+
+data class MessageBody(
+    val text: String? = null,
+    val attachmentUrl: String? = null,
+    val attachmentMimeType: String? = null,
 )

--- a/app/src/main/java/com/example/texty/model/SessionKeyInfo.kt
+++ b/app/src/main/java/com/example/texty/model/SessionKeyInfo.kt
@@ -1,0 +1,10 @@
+package com.example.texty.model
+
+data class SessionKeyInfo(
+    val roomId: String,
+    val ownerUid: String,
+    val rootKey: ByteArray?,
+    val schemeVersion: Int,
+    val encryptionTarget: String,
+    val requiresReauth: Boolean = false,
+)

--- a/app/src/main/java/com/example/texty/repository/MessageMapper.kt
+++ b/app/src/main/java/com/example/texty/repository/MessageMapper.kt
@@ -1,0 +1,179 @@
+package com.example.texty.repository
+
+import com.example.texty.model.DecryptedMessage
+import com.example.texty.model.EncryptionPayload
+import com.example.texty.model.Message
+import com.example.texty.model.MessageBody
+import com.example.texty.model.SessionKeyInfo
+import com.example.texty.util.MessageCrypto
+import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.SetOptions
+import java.util.Locale
+
+class MessageMapper(
+    private val sessionKeyInfo: SessionKeyInfo?,
+) {
+    data class MessageDocument(
+        val snapshot: DocumentSnapshot,
+        val message: Message,
+        val body: MessageBody?,
+        val encryptionPayload: EncryptionPayload?,
+        val encryptionMetadata: MessageCrypto.EncryptionMetadata?,
+    )
+
+    fun map(snapshot: DocumentSnapshot): MessageDocument? {
+        val senderId = snapshot.getString("senderId") ?: return null
+        val senderName = snapshot.getString("senderName") ?: ""
+        val createdAt = snapshot.getTimestamp("createdAt")
+        val readBy = snapshot.get("readBy") as? List<*> ?: emptyList<Any>()
+        val readByStrings = readBy.mapNotNull { it as? String }
+        val messageType = snapshot.getString("messageType") ?: deriveLegacyType(snapshot)
+        val encryptionPayload = buildEncryptionPayload(snapshot)
+        val encryptionMetadata = encryptionPayload?.let { payload ->
+            MessageCrypto.EncryptionMetadata(
+                senderId = senderId,
+                messageType = messageType,
+                readBy = readByStrings,
+                schemeVersion = payload.schemeVersion,
+                encryptionTarget = payload.encryptionTarget.ifEmpty { sessionKeyInfo?.encryptionTarget ?: "" },
+            )
+        }
+
+        val decryptedResult = if (encryptionPayload != null && encryptionMetadata != null) {
+            MessageCrypto.decrypt(sessionKeyInfo, encryptionPayload, encryptionMetadata)
+        } else {
+            null
+        }
+
+        val body = when {
+            decryptedResult?.body != null -> decryptedResult.body
+            encryptionPayload == null -> buildLegacyBody(snapshot)
+            else -> null
+        }
+
+        val displayText = when {
+            body != null -> buildDisplayText(body, messageType)
+            decryptedResult != null && decryptedResult.body == null -> null
+            else -> null
+        }
+
+        val decryptedMessage = body?.let {
+            DecryptedMessage(
+                body = it,
+                displayText = displayText ?: "",
+            )
+        }
+
+        val message = Message(
+            id = snapshot.id,
+            senderId = senderId,
+            senderName = senderName,
+            createdAt = createdAt,
+            readBy = readByStrings,
+            messageType = messageType,
+            encryption = encryptionPayload,
+            decrypted = decryptedMessage,
+            decryptionError = decryptedResult?.body == null && encryptionPayload != null,
+            requiresKeyResync = decryptedResult?.requiresResync == true || (sessionKeyInfo?.requiresReauth == true),
+        )
+
+        return MessageDocument(
+            snapshot = snapshot,
+            message = message,
+            body = body,
+            encryptionPayload = encryptionPayload,
+            encryptionMetadata = encryptionMetadata,
+        )
+    }
+
+    fun buildReadReceiptUpdate(
+        document: MessageDocument,
+        readerUid: String,
+    ): Pair<Map<String, Any>, SetOptions>? {
+        val currentReadBy = document.message.readBy.toMutableSet()
+        if (!currentReadBy.add(readerUid)) {
+            return null
+        }
+        val updatedReadBy = currentReadBy.toList().sorted()
+
+        val payload = document.encryptionPayload
+        val metadata = document.encryptionMetadata
+        val body = document.body
+
+        if (payload != null && metadata != null && body != null) {
+            val newMetadata = metadata.copy(readBy = updatedReadBy)
+            val result = MessageCrypto.reEncryptWithUpdatedReadReceipts(
+                sessionKey = sessionKeyInfo,
+                body = body,
+                metadata = newMetadata,
+            ) ?: return null
+
+            val update = mapOf(
+                "ciphertext" to result.payload.ciphertext,
+                "nonce" to result.payload.nonce,
+                "salt" to result.payload.salt,
+                "schemeVersion" to result.payload.schemeVersion,
+                "encryptionTarget" to result.payload.encryptionTarget,
+                "readBy" to updatedReadBy,
+            )
+            return update to SetOptions.merge()
+        }
+
+        val fallbackUpdate = mapOf(
+            "readBy" to updatedReadBy,
+        )
+        return fallbackUpdate to SetOptions.merge()
+    }
+
+    private fun buildEncryptionPayload(snapshot: DocumentSnapshot): EncryptionPayload? {
+        val ciphertext = snapshot.getString("ciphertext") ?: return null
+        val nonce = snapshot.getString("nonce") ?: return null
+        val salt = snapshot.getString("salt") ?: return null
+        val schemeVersion = snapshot.getLong("schemeVersion")?.toInt()
+            ?: sessionKeyInfo?.schemeVersion
+            ?: MessageCrypto.CURRENT_SCHEME_VERSION
+        val encryptionTarget = snapshot.getString("encryptionTarget")
+            ?: sessionKeyInfo?.encryptionTarget
+            ?: ""
+        return EncryptionPayload(
+            ciphertext = ciphertext,
+            nonce = nonce,
+            salt = salt,
+            schemeVersion = schemeVersion,
+            encryptionTarget = encryptionTarget,
+        )
+    }
+
+    private fun buildLegacyBody(snapshot: DocumentSnapshot): MessageBody? {
+        val text = snapshot.getString("text")
+        val imageUrl = snapshot.getString("imageUrl")
+        if (text == null && imageUrl == null) {
+            return null
+        }
+        val mimeType = imageUrl?.let { "media/image" }
+        return MessageBody(
+            text = text,
+            attachmentUrl = imageUrl,
+            attachmentMimeType = mimeType,
+        )
+    }
+
+    private fun deriveLegacyType(snapshot: DocumentSnapshot): String {
+        return when {
+            !snapshot.getString("imageUrl").isNullOrEmpty() -> "media/image"
+            !snapshot.getString("text").isNullOrEmpty() -> "text/plain"
+            else -> "application/octet-stream"
+        }
+    }
+
+    private fun buildDisplayText(body: MessageBody, messageType: String?): String {
+        val normalizedType = messageType?.lowercase(Locale.US) ?: ""
+        return when {
+            normalizedType.startsWith("text") -> body.text.orEmpty()
+            normalizedType.contains("image") -> "\uD83D\uDCF7 Imagen cifrada"
+            normalizedType.startsWith("media") -> "\uD83D\uDCCE Archivo cifrado"
+            body.text != null -> body.text
+            else -> "\uD83D\uDCCE Archivo cifrado"
+        }
+    }
+}

--- a/app/src/main/java/com/example/texty/repository/SessionKeyRepository.kt
+++ b/app/src/main/java/com/example/texty/repository/SessionKeyRepository.kt
@@ -1,0 +1,79 @@
+package com.example.texty.repository
+
+import android.util.Base64
+import com.example.texty.model.SessionKeyInfo
+import com.example.texty.util.MessageCrypto
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
+import kotlinx.coroutines.tasks.await
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+
+class SessionKeyRepository(
+    private val firestore: FirebaseFirestore = Firebase.firestore,
+) {
+    suspend fun loadSessionKey(
+        roomId: String,
+        ownerUid: String,
+        isGroup: Boolean,
+        peerUid: String? = null,
+    ): SessionKeyInfo {
+        if (isGroup) {
+            val groupKey = deriveGroupKeyMaterial(roomId)
+            return SessionKeyInfo(
+                roomId = roomId,
+                ownerUid = ownerUid,
+                rootKey = groupKey,
+                schemeVersion = MessageCrypto.CURRENT_SCHEME_VERSION,
+                encryptionTarget = "group:$roomId",
+                requiresReauth = false,
+            )
+        }
+
+        val participantDoc = firestore.collection("sessions")
+            .document(roomId)
+            .collection("participants")
+            .document(ownerUid)
+            .get()
+            .await()
+
+        if (!participantDoc.exists()) {
+            return SessionKeyInfo(
+                roomId = roomId,
+                ownerUid = ownerUid,
+                rootKey = null,
+                schemeVersion = MessageCrypto.CURRENT_SCHEME_VERSION,
+                encryptionTarget = "direct:${peerUid ?: "unknown"}",
+                requiresReauth = true,
+            )
+        }
+
+        val rootKeyMaterial = participantDoc.getString("rootKeyMaterial")
+        val protocolVersion = participantDoc.getLong("protocolVersion")?.toInt()
+            ?: MessageCrypto.CURRENT_SCHEME_VERSION
+        val targetPeer = participantDoc.getString("peerUid") ?: peerUid ?: "unknown"
+        val requiresReauth = participantDoc.getBoolean("requiresReauth") ?: false
+
+        val rootKey = rootKeyMaterial?.let { decodeBase64(it) }
+
+        return SessionKeyInfo(
+            roomId = roomId,
+            ownerUid = ownerUid,
+            rootKey = rootKey,
+            schemeVersion = protocolVersion,
+            encryptionTarget = "direct:$targetPeer",
+            requiresReauth = requiresReauth || rootKey == null,
+        )
+    }
+
+    private fun decodeBase64(value: String): ByteArray =
+        Base64.decode(value, Base64.NO_WRAP)
+
+    private fun deriveGroupKeyMaterial(roomId: String): ByteArray {
+        val digest = MessageDigest.getInstance("SHA-256")
+        digest.update("group".toByteArray(StandardCharsets.UTF_8))
+        digest.update(roomId.toByteArray(StandardCharsets.UTF_8))
+        return digest.digest()
+    }
+}

--- a/app/src/main/java/com/example/texty/ui/ChatAdapter.kt
+++ b/app/src/main/java/com/example/texty/ui/ChatAdapter.kt
@@ -1,7 +1,5 @@
 package com.example.texty.ui
 
-import com.bumptech.glide.Glide
-
 import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
@@ -62,34 +60,39 @@ class ChatAdapter(
     override fun onBindViewHolder(holder: MessageViewHolder, position: Int) {
         val message = getItem(position)
 
-        if (!message.text.isNullOrBlank()) {
-            holder.messageText.visibility = View.VISIBLE
-            holder.imageView.visibility = View.GONE
-            holder.messageText.text = message.text
-        } else if (!message.imageUrl.isNullOrBlank()) {
-            holder.messageText.visibility = View.GONE
-            holder.imageView.visibility = View.VISIBLE
-            Glide.with(holder.itemView.context)
-                .load(message.imageUrl)
-                .into(holder.imageView)
+        holder.imageView.visibility = View.GONE
+        val context = holder.itemView.context
+        val decrypted = message.decrypted
+        val textToDisplay = when {
+            message.decryptionError -> {
+                if (message.requiresKeyResync) {
+                    context.getString(R.string.chat_message_unavailable_resync)
+                } else {
+                    context.getString(R.string.chat_message_unavailable)
+                }
+            }
+
+            decrypted != null -> {
+                val value = decrypted.displayText.trim()
+                if (value.isNotEmpty()) {
+                    value
+                } else {
+                    context.getString(R.string.chat_message_empty_placeholder)
+                }
+            }
+
+            else -> context.getString(R.string.chat_message_unavailable)
         }
+
+        holder.messageText.visibility = View.VISIBLE
+        holder.messageText.text = textToDisplay
 
         if (message.senderId == myUid) {
             holder.root.gravity = Gravity.END
-            if (holder.messageText.visibility == View.VISIBLE) {
-                holder.messageText.setBackgroundResource(R.drawable.bubble_outgoing)
-            }
-            if (holder.imageView.visibility == View.VISIBLE) {
-                holder.imageView.setBackgroundResource(R.drawable.bubble_outgoing)
-            }
+            holder.messageText.setBackgroundResource(R.drawable.bubble_outgoing)
         } else {
             holder.root.gravity = Gravity.START
-            if (holder.messageText.visibility == View.VISIBLE) {
-                holder.messageText.setBackgroundResource(R.drawable.bubble_incoming)
-            }
-            if (holder.imageView.visibility == View.VISIBLE) {
-                holder.imageView.setBackgroundResource(R.drawable.bubble_incoming)
-            }
+            holder.messageText.setBackgroundResource(R.drawable.bubble_incoming)
         }
 
         val ts = message.createdAt

--- a/app/src/main/java/com/example/texty/util/MessageCrypto.kt
+++ b/app/src/main/java/com/example/texty/util/MessageCrypto.kt
@@ -1,0 +1,207 @@
+package com.example.texty.util
+
+import android.util.Base64
+import com.example.texty.model.EncryptionPayload
+import com.example.texty.model.MessageBody
+import com.example.texty.model.SessionKeyInfo
+import com.google.crypto.tink.subtle.Hkdf
+import com.google.crypto.tink.subtle.XChaCha20Poly1305
+import java.nio.charset.StandardCharsets
+import java.security.GeneralSecurityException
+import java.security.SecureRandom
+import org.json.JSONObject
+
+object MessageCrypto {
+    const val CURRENT_SCHEME_VERSION = 1
+    private const val KEY_SIZE_BYTES = 32
+    private const val NONCE_SIZE_BYTES = 24
+    private const val SALT_SIZE_BYTES = 32
+
+    private val secureRandom = SecureRandom()
+
+    data class EncryptionMetadata(
+        val senderId: String,
+        val messageType: String,
+        val readBy: List<String>,
+        val schemeVersion: Int,
+        val encryptionTarget: String,
+    )
+
+    data class EncryptionResult(
+        val payload: EncryptionPayload,
+        val readBy: List<String>,
+    )
+
+    data class DecryptionResult(
+        val body: MessageBody? = null,
+        val errorMessage: String? = null,
+        val requiresResync: Boolean = false,
+    )
+
+    fun encrypt(
+        sessionKey: SessionKeyInfo,
+        body: MessageBody,
+        metadata: EncryptionMetadata,
+    ): EncryptionResult {
+        val rootKey = sessionKey.rootKey
+            ?: throw IllegalStateException("Missing session root key for encryption")
+
+        val salt = ByteArray(SALT_SIZE_BYTES).apply { secureRandom.nextBytes(this) }
+        val derivedKey = Hkdf.computeHkdf(
+            "HmacSha256",
+            rootKey,
+            salt,
+            metadata.hkdfInfo(),
+            KEY_SIZE_BYTES,
+        )
+
+        val nonceAndCiphertext = XChaCha20Poly1305(derivedKey).encrypt(
+            body.toJsonBytes(),
+            metadata.associatedData(),
+        )
+
+        val nonce = nonceAndCiphertext.copyOfRange(0, NONCE_SIZE_BYTES)
+        val ciphertext = nonceAndCiphertext.copyOfRange(NONCE_SIZE_BYTES, nonceAndCiphertext.size)
+
+        val payload = EncryptionPayload(
+            ciphertext = Base64.encodeToString(ciphertext, Base64.NO_WRAP),
+            nonce = Base64.encodeToString(nonce, Base64.NO_WRAP),
+            salt = Base64.encodeToString(salt, Base64.NO_WRAP),
+            schemeVersion = metadata.schemeVersion,
+            encryptionTarget = metadata.encryptionTarget,
+        )
+
+        return EncryptionResult(
+            payload = payload,
+            readBy = metadata.readBy,
+        )
+    }
+
+    fun decrypt(
+        sessionKey: SessionKeyInfo?,
+        payload: EncryptionPayload,
+        metadata: EncryptionMetadata,
+    ): DecryptionResult {
+        val rootKey = sessionKey?.rootKey
+            ?: return DecryptionResult(
+                body = null,
+                errorMessage = "missing_session_key",
+                requiresResync = true,
+            )
+
+        return try {
+            val salt = Base64.decode(payload.salt, Base64.NO_WRAP)
+            val nonce = Base64.decode(payload.nonce, Base64.NO_WRAP)
+            val ciphertext = Base64.decode(payload.ciphertext, Base64.NO_WRAP)
+
+            val derivedKey = Hkdf.computeHkdf(
+                "HmacSha256",
+                rootKey,
+                salt,
+                metadata.hkdfInfo(),
+                KEY_SIZE_BYTES,
+            )
+
+            val nonceAndCiphertext = ByteArray(nonce.size + ciphertext.size)
+            System.arraycopy(nonce, 0, nonceAndCiphertext, 0, nonce.size)
+            System.arraycopy(ciphertext, 0, nonceAndCiphertext, nonce.size, ciphertext.size)
+
+            val plaintext = XChaCha20Poly1305(derivedKey).decrypt(
+                nonceAndCiphertext,
+                metadata.associatedData(),
+            )
+
+            DecryptionResult(
+                body = parseBody(plaintext),
+                errorMessage = null,
+                requiresResync = false,
+            )
+        } catch (error: GeneralSecurityException) {
+            DecryptionResult(
+                body = null,
+                errorMessage = sanitizeErrorMessage(error),
+                requiresResync = true,
+            )
+        } catch (error: Exception) {
+            DecryptionResult(
+                body = null,
+                errorMessage = sanitizeErrorMessage(error),
+                requiresResync = false,
+            )
+        }
+    }
+
+    fun reEncryptWithUpdatedReadReceipts(
+        sessionKey: SessionKeyInfo?,
+        body: MessageBody?,
+        metadata: EncryptionMetadata,
+    ): EncryptionResult? {
+        val rootKey = sessionKey?.rootKey ?: return null
+        val safeBody = body ?: return null
+        return encrypt(
+            sessionKey.copy(rootKey = rootKey),
+            safeBody,
+            metadata,
+        )
+    }
+
+    private fun EncryptionMetadata.hkdfInfo(): ByteArray {
+        val info = buildString {
+            append("msg|")
+            append(schemeVersion)
+            append('|')
+            append(encryptionTarget)
+            append('|')
+            append(messageType)
+        }
+        return info.toByteArray(StandardCharsets.UTF_8)
+    }
+
+    private fun EncryptionMetadata.associatedData(): ByteArray {
+        val readReceipts = readBy.sorted().joinToString(",")
+        val payload = buildString {
+            append("ad|")
+            append(schemeVersion)
+            append('|')
+            append(senderId)
+            append('|')
+            append(messageType)
+            append('|')
+            append(encryptionTarget)
+            append('|')
+            append(readReceipts)
+        }
+        return payload.toByteArray(StandardCharsets.UTF_8)
+    }
+
+    private fun MessageBody.toJsonBytes(): ByteArray {
+        val json = JSONObject()
+        if (text != null) json.put("text", text)
+        if (attachmentUrl != null) json.put("attachmentUrl", attachmentUrl)
+        if (attachmentMimeType != null) json.put("attachmentMimeType", attachmentMimeType)
+        return json.toString().toByteArray(StandardCharsets.UTF_8)
+    }
+
+    private fun parseBody(bytes: ByteArray): MessageBody {
+        val json = JSONObject(String(bytes, StandardCharsets.UTF_8))
+        val text = if (json.has("text") && !json.isNull("text")) json.getString("text") else null
+        val attachmentUrl = if (json.has("attachmentUrl") && !json.isNull("attachmentUrl")) {
+            json.getString("attachmentUrl")
+        } else {
+            null
+        }
+        val attachmentMimeType = if (json.has("attachmentMimeType") && !json.isNull("attachmentMimeType")) {
+            json.getString("attachmentMimeType")
+        } else {
+            null
+        }
+        return MessageBody(
+            text = text,
+            attachmentUrl = attachmentUrl,
+            attachmentMimeType = attachmentMimeType,
+        )
+    }
+
+    private fun sanitizeErrorMessage(error: Exception): String =
+        error.javaClass.simpleName.ifEmpty { "crypto_error" }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,4 +30,12 @@
     <string name="privacy">Privacidad</string>
     <string name="private_account">Cuenta privada</string>
     <string name="error_not_friends">Debes ser amigo para chatear</string>
+    <string name="chat_message_unavailable">Mensaje no disponible</string>
+    <string name="chat_message_unavailable_resync">Mensaje no disponible. Sincroniza tus claves.</string>
+    <string name="chat_message_empty_placeholder">Mensaje vacío</string>
+    <string name="chat_session_requires_resync">No se pudo validar la sesión cifrada. Sincroniza tus claves.</string>
+    <string name="chat_session_missing_keys">No se encontró la clave de sesión. Re-sincroniza antes de enviar.</string>
+    <string name="chat_message_encrypt_error">No se pudo cifrar el mensaje.</string>
+    <string name="chat_message_send_error">No se pudo enviar el mensaje.</string>
+    <string name="chat_message_image_preview">📷 Imagen cifrada</string>
 </resources>


### PR DESCRIPTION
## Summary
- add AEAD-based message encryption utilities and session key lookup helpers
- decrypt Firestore snapshots before display and refresh ciphertext when marking messages as read
- update chat UI to surface decrypted placeholders and add localized messaging for crypto errors

## Testing
- ./gradlew test *(fails: Unable to download Gradle distribution due to proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ca420610b08320baa26d9385205417