### PR TITLE
Improve profile save feedback

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,6 +25,7 @@
     <string name="profile_phone">Teléfono</string>
     <string name="change_password">Cambiar contraseña</string>
     <string name="password_reset_email_sent">Correo de restablecimiento enviado</string>
+    <string name="profile_saved_success">Perfil guardado</string>
     <string name="notifications">Notificaciones</string>
     <string name="enable_notifications">Recibir notificaciones</string>
     <string name="privacy">Privacidad</string>


### PR DESCRIPTION
## Summary
- handle errors when uploading profile images, updating the auth profile, or writing to Firestore by restoring the previous UI state and surfacing a toast
- disable the save button while profile changes are in progress and show a success toast when the profile is stored
- add a localized string resource for the profile save confirmation message

## Testing
- `./gradlew :app:lint` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68ccd63b508883209acd08b4dc803821