### PR TITLE
Cap unread badge and add tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -81,6 +81,8 @@ dependencies {
     // Tests
     testImplementation("junit:junit:4.13.2")
     testImplementation("io.mockk:mockk:1.13.8")
+    testImplementation("org.robolectric:robolectric:4.11.1")
+    testImplementation("androidx.test:core:1.5.0")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
     androidTestImplementation("io.mockk:mockk-android:1.13.8")

--- a/app/src/main/java/com/example/texty/ui/ChatListAdapter.kt
+++ b/app/src/main/java/com/example/texty/ui/ChatListAdapter.kt
@@ -61,7 +61,7 @@ class ChatListAdapter(
         val currentUid = Firebase.auth.currentUser?.uid
         val count = currentUid?.let { room.unreadCounts[it] } ?: 0
         holder.unreadCountText.apply {
-            text = count.toString()
+            text = if (count > 6) "6+" else count.toString()
             visibility = if (count > 0) View.VISIBLE else View.GONE
         }
 

--- a/app/src/test/java/com/example/texty/ui/ChatListAdapterTest.kt
+++ b/app/src/test/java/com/example/texty/ui/ChatListAdapterTest.kt
@@ -1,0 +1,89 @@
+package com.example.texty.ui
+
+import android.os.Looper
+import android.view.View
+import android.widget.FrameLayout
+import androidx.test.core.app.ApplicationProvider
+import com.example.texty.model.ChatRoom
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.ktx.Firebase
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+@RunWith(RobolectricTestRunner::class)
+class ChatListAdapterTest {
+
+    private val currentUid = "current-user"
+
+    @Before
+    fun setUp() {
+        mockkStatic("com.google.firebase.auth.ktx.FirebaseAuthKt")
+        val auth = mockk<FirebaseAuth>()
+        val user = mockk<FirebaseUser>()
+
+        every { user.uid } returns currentUid
+        every { auth.currentUser } returns user
+        every { Firebase.auth } returns auth
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun unreadCountGreaterThanSixShowsCappedLabel() {
+        val adapter = ChatListAdapter { }
+        val holder = createViewHolder(adapter)
+        val room = ChatRoom(
+            id = "room-1",
+            isGroup = true,
+            groupName = "Group",
+            unreadCounts = mapOf(currentUid to 7)
+        )
+
+        adapter.submitList(listOf(room))
+        shadowOf(Looper.getMainLooper()).idle()
+
+        adapter.onBindViewHolder(holder, 0)
+
+        assertEquals(View.VISIBLE, holder.unreadCountText.visibility)
+        assertEquals("6+", holder.unreadCountText.text.toString())
+    }
+
+    @Test
+    fun unreadCountLessOrEqualToSixShowsExactValue() {
+        val adapter = ChatListAdapter { }
+        val holder = createViewHolder(adapter)
+        val room = ChatRoom(
+            id = "room-2",
+            isGroup = true,
+            groupName = "Group",
+            unreadCounts = mapOf(currentUid to 3)
+        )
+
+        adapter.submitList(listOf(room))
+        shadowOf(Looper.getMainLooper()).idle()
+
+        adapter.onBindViewHolder(holder, 0)
+
+        assertEquals(View.VISIBLE, holder.unreadCountText.visibility)
+        assertEquals("3", holder.unreadCountText.text.toString())
+    }
+
+    private fun createViewHolder(adapter: ChatListAdapter): ChatListAdapter.ChatRoomViewHolder {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val parent = FrameLayout(context)
+        return adapter.onCreateViewHolder(parent, 0)
+    }
+}


### PR DESCRIPTION
## Summary
- cap chat unread count badges to display "6+" when the count exceeds six
- add Robolectric-based unit tests that verify unread counts of 7 show "6+" and 3 shows "3"
- include test dependencies required for the new UI test coverage

## Testing
- ./gradlew test *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68ccd7f207408320b43b599e18217ed9