### PR TITLE
Adjust chat list badges and timestamp

### DIFF
--- a/app/src/main/java/com/example/texty/ui/ChatListAdapter.kt
+++ b/app/src/main/java/com/example/texty/ui/ChatListAdapter.kt
@@ -12,6 +12,7 @@ import com.example.texty.model.ChatRoom
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
+import java.text.DateFormat
 
 class ChatListAdapter(
     private val onClick: (ChatRoom) -> Unit,
@@ -22,6 +23,7 @@ class ChatListAdapter(
         val lastMessageText: TextView = view.findViewById(R.id.textLastMessage)
         val statusView: View = view.findViewById(R.id.viewStatus)
         val unreadCountText: TextView = view.findViewById(R.id.textUnreadCount)
+        val lastUpdatedText: TextView = view.findViewById(R.id.textLastUpdated)
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ChatRoomViewHolder {
@@ -61,8 +63,14 @@ class ChatListAdapter(
         val currentUid = Firebase.auth.currentUser?.uid
         val count = currentUid?.let { room.unreadCounts[it] } ?: 0
         holder.unreadCountText.apply {
-            text = if (count > 6) "6+" else count.toString()
+            text = count.toString()
             visibility = if (count > 0) View.VISIBLE else View.GONE
+        }
+
+        val formattedTime = room.updatedAt?.toDate()?.let { timeFormatter.format(it) }
+        holder.lastUpdatedText.apply {
+            text = formattedTime ?: ""
+            visibility = if (formattedTime != null) View.VISIBLE else View.GONE
         }
 
         // Estado online SOLO en chats individuales
@@ -89,6 +97,7 @@ class ChatListAdapter(
         holder.itemView.setOnClickListener { onClick(room) }
     }
     companion object {
+        private val timeFormatter = DateFormat.getTimeInstance(DateFormat.SHORT)
         private val DIFF_CALLBACK = object : DiffUtil.ItemCallback<ChatRoom>() {
             override fun areItemsTheSame(oldItem: ChatRoom, newItem: ChatRoom): Boolean {
                 return oldItem.id == newItem.id

--- a/app/src/main/res/drawable/unread_badge.xml
+++ b/app/src/main/res/drawable/unread_badge.xml
@@ -1,3 +1,3 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="oval">
-    <solid android:color="@android:color/holo_red_dark" />
+    <solid android:color="@color/md_theme_light_success" />
 </shape>

--- a/app/src/main/res/layout/item_chat.xml
+++ b/app/src/main/res/layout/item_chat.xml
@@ -52,19 +52,37 @@
                     android:visibility="gone" />
         </LinearLayout>
 
-        <TextView
-                android:id="@+id/textUnreadCount"
+        <LinearLayout
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:minWidth="24dp"
-                android:minHeight="24dp"
-                android:gravity="center"
-                android:background="@drawable/unread_badge"
-                android:textColor="@android:color/white"
-                android:textStyle="bold"
-                android:visibility="gone"
-                android:layout_gravity="center_vertical"
-                android:layout_marginStart="8dp"/>
+                android:layout_height="match_parent"
+                android:gravity="end"
+                android:orientation="vertical"
+                android:layout_marginStart="8dp"
+                android:layout_gravity="center_vertical">
+
+            <TextView
+                    android:id="@+id/textLastUpdated"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:gravity="end"
+                    android:textColor="@color/md_theme_light_success"
+                    android:textSize="12sp"
+                    android:visibility="gone" />
+
+            <TextView
+                    android:id="@+id/textUnreadCount"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:minWidth="24dp"
+                    android:minHeight="24dp"
+                    android:gravity="center"
+                    android:background="@drawable/unread_badge"
+                    android:textColor="@android:color/white"
+                    android:textStyle="bold"
+                    android:visibility="gone"
+                    android:layout_marginTop="4dp"
+                    android:layout_gravity="end"/>
+        </LinearLayout>
     </LinearLayout>
 
 </com.google.android.material.card.MaterialCardView>


### PR DESCRIPTION
## Summary
- show the actual unread message total instead of truncating at "6+" and surface the last update time in the chat list
- reorganize the chat row layout so the timestamp appears above the unread badge for a WhatsApp-like presentation
- recolor the unread badge with the app's success green to match the desired notification style

## Testing
- ./gradlew lint *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68d37c5cd1ac832084830b61d14dd814