### PR TITLE
Add WhatsApp-style sent message banner

### DIFF
--- a/app/src/main/res/layout/activity_chat.xml
+++ b/app/src/main/res/layout/activity_chat.xml
@@ -19,6 +19,62 @@
             android:theme="@style/ThemeOverlay.Material3.Dark.ActionBar" />
     </com.google.android.material.appbar.AppBarLayout>
 
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/messageBanner"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginTop="8dp"
+        android:visibility="gone"
+        app:cardBackgroundColor="?attr/colorSurface"
+        app:cardElevation="4dp"
+        app:shapeAppearanceOverlay="@style/ShapeAppearance.Material3.Corner.Medium">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:paddingHorizontal="16dp"
+            android:paddingVertical="12dp">
+
+            <ImageView
+                android:id="@+id/messageBannerIcon"
+                android:layout_width="32dp"
+                android:layout_height="32dp"
+                android:contentDescription="@string/chat_banner_icon_content_description"
+                android:padding="4dp"
+                android:src="@drawable/ic_send"
+                android:tint="?attr/colorPrimary" />
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="12dp"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/messageBannerTitle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:ellipsize="end"
+                    android:maxLines="1"
+                    android:textAppearance="@style/TextAppearance.Material3.TitleSmall"
+                    android:textColor="?attr/colorOnSurface" />
+
+                <TextView
+                    android:id="@+id/messageBannerSubtitle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:ellipsize="end"
+                    android:maxLines="1"
+                    android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+                    android:textColor="?attr/colorOnSurfaceVariant" />
+            </LinearLayout>
+        </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerView"
         android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,6 +39,9 @@
     <string name="chat_message_encrypt_error">No se pudo cifrar el mensaje.</string>
     <string name="chat_message_send_error">No se pudo enviar el mensaje.</string>
     <string name="chat_message_image_preview">📷 Imagen cifrada</string>
+    <string name="chat_banner_icon_content_description">Mensaje enviado</string>
+    <string name="chat_banner_message_sent">Mensaje enviado</string>
+    <string name="chat_banner_preview_with_time">%1$s · %2$s</string>
     <string name="notification_generic_title">Nuevo mensaje</string>
     <string name="notification_generic_body">Tienes un mensaje nuevo</string>
     <plurals name="notification_new_messages">


### PR DESCRIPTION
## Summary
- add a material banner above the chat list to mirror WhatsApp style confirmations
- show and auto-hide the banner after a successful outgoing message and switch icons based on the message type
- add supporting strings for banner accessibility and text formatting

## Testing
- ⚠️ `./gradlew lint` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68d380ccde208320a28009c08b9494e4