### PR TITLE
Refine Texty UI styling and add subtle animations

### DIFF
--- a/app/src/main/java/com/example/texty/ui/ChatAdapter.kt
+++ b/app/src/main/java/com/example/texty/ui/ChatAdapter.kt
@@ -52,9 +52,11 @@ class ChatAdapter(
         if (message.senderId == myUid) {
             holder.root.gravity = Gravity.END
             holder.messageText.setBackgroundResource(R.drawable.bubble_outgoing)
+            holder.imageView.setBackgroundResource(R.drawable.bubble_outgoing)
         } else {
             holder.root.gravity = Gravity.START
             holder.messageText.setBackgroundResource(R.drawable.bubble_incoming)
+            holder.imageView.setBackgroundResource(R.drawable.bubble_incoming)
         }
     }*/
 
@@ -92,9 +94,11 @@ class ChatAdapter(
         if (message.senderId == myUid) {
             holder.root.gravity = Gravity.END
             holder.messageText.setBackgroundResource(R.drawable.bubble_outgoing)
+            holder.imageView.setBackgroundResource(R.drawable.bubble_outgoing)
         } else {
             holder.root.gravity = Gravity.START
             holder.messageText.setBackgroundResource(R.drawable.bubble_incoming)
+            holder.imageView.setBackgroundResource(R.drawable.bubble_incoming)
         }
 
         val ts = message.createdAt

--- a/app/src/main/java/com/example/texty/ui/ChatListFragment.kt
+++ b/app/src/main/java/com/example/texty/ui/ChatListFragment.kt
@@ -4,30 +4,26 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.*
 import android.widget.CheckBox
-import android.widget.ProgressBar
-import com.google.firebase.auth.ktx.auth
 import android.widget.TextView
 import androidx.core.widget.addTextChangedListener
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.texty.R
 import com.example.texty.model.ChatRoom
 import com.example.texty.model.User
 import com.google.firebase.auth.ktx.auth
-import androidx.core.widget.addTextChangedListener
 import java.util.Locale
 import com.example.texty.repository.ChatRoomRepository
 import com.example.texty.repository.UserRepository
 import com.example.texty.util.AppLogger
 import com.example.texty.util.ErrorLogger
 import com.google.android.material.appbar.MaterialToolbar
+import com.google.android.material.progressindicator.CircularProgressIndicator
 import com.google.android.material.textfield.TextInputEditText
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.ktx.Firebase
-import java.util.*
 
 class ChatListFragment : Fragment() {
     private val viewModel: ChatListViewModel by viewModels()
@@ -36,7 +32,7 @@ class ChatListFragment : Fragment() {
     private var allRooms: List<ChatRoom> = emptyList()
     private lateinit var recycler: RecyclerView
     private lateinit var placeholder: TextView
-    private lateinit var progressBar: ProgressBar
+    private lateinit var progressBar: CircularProgressIndicator
     private var cachedFriends: List<User>? = null
     private var pendingRooms: List<ChatRoom>? = null
     private val userRepository = UserRepository()
@@ -90,10 +86,6 @@ class ChatListFragment : Fragment() {
 
         recycler.layoutManager = LinearLayoutManager(requireContext())
         recycler.adapter = adapter
-        recycler.addItemDecoration(
-            DividerItemDecoration(requireContext(), DividerItemDecoration.VERTICAL)
-        )
-
         searchInput = view.findViewById(R.id.editSearch)
         searchInput.addTextChangedListener { text ->
             filterRooms(text?.toString() ?: "")
@@ -239,6 +231,7 @@ class ChatListFragment : Fragment() {
             }
             adapter.submitList(filtered)
         }
+        recycler.scheduleLayoutAnimation()
     }
 
     private fun openCreateGroupDialog() {

--- a/app/src/main/java/com/example/texty/ui/LoginActivity.kt
+++ b/app/src/main/java/com/example/texty/ui/LoginActivity.kt
@@ -4,7 +4,6 @@ import android.content.Intent
 import android.os.Bundle
 import android.util.Patterns
 import android.view.View
-import android.widget.ProgressBar
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.example.texty.R
@@ -18,6 +17,7 @@ import com.google.firebase.auth.FirebaseAuthInvalidCredentialsException
 import com.google.firebase.auth.FirebaseAuthInvalidUserException
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
+import com.google.android.material.progressindicator.CircularProgressIndicator
 
 class LoginActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -41,7 +41,7 @@ class LoginActivity : AppCompatActivity() {
     val passwordInput = findViewById<TextInputEditText>(R.id.editPassword)
     val loginButton = findViewById<Button>(R.id.buttonLogin)
     val registerButton = findViewById<Button>(R.id.buttonRegister)
-    val progressBar = findViewById<ProgressBar>(R.id.progressBar)
+    val progressBar = findViewById<CircularProgressIndicator>(R.id.progressBar)
 
     loginButton.setOnClickListener {
       val email = emailInput.text.toString().trim()

--- a/app/src/main/res/anim/fade_through_item.xml
+++ b/app/src/main/res/anim/fade_through_item.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="220"
+    android:interpolator="@android:interpolator/fast_out_slow_in">
+
+    <alpha
+        android:fromAlpha="0"
+        android:toAlpha="1" />
+
+    <scale
+        android:fromXScale="0.95"
+        android:fromYScale="0.95"
+        android:pivotX="50%"
+        android:pivotY="50%"
+        android:toXScale="1"
+        android:toYScale="1" />
+</set>

--- a/app/src/main/res/anim/layout_fade_through.xml
+++ b/app/src/main/res/anim/layout_fade_through.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layoutAnimation xmlns:android="http://schemas.android.com/apk/res/android"
+    android:animationOrder="normal"
+    android:delay="20%"
+    android:animation="@anim/fade_through_item" />

--- a/app/src/main/res/color/text_input_hint.xml
+++ b/app/src/main/res/color/text_input_hint.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="true" android:color="@color/md_theme_light_primary" />
+    <item android:color="@color/md_theme_light_onSurfaceVariant" />
+</selector>

--- a/app/src/main/res/color/text_input_icon.xml
+++ b/app/src/main/res/color/text_input_icon.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="true" android:color="@color/md_theme_light_primary" />
+    <item android:color="@color/md_theme_light_onSurfaceVariant" />
+</selector>

--- a/app/src/main/res/color/text_input_stroke.xml
+++ b/app/src/main/res/color/text_input_stroke.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_error="true" android:color="@color/colorError" />
+    <item android:state_focused="true" android:color="@color/md_theme_light_primary" />
+    <item android:color="@color/md_theme_light_outline" />
+</selector>

--- a/app/src/main/res/drawable/bubble_incoming.xml
+++ b/app/src/main/res/drawable/bubble_incoming.xml
@@ -2,17 +2,18 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
        android:shape="rectangle">
 
-    <!-- Usa el color de superficie variante de M3 -->
-    <solid android:color="?attr/colorSurfaceVariant" />
+    <solid android:color="?attr/colorSurface" />
 
-    <!-- Esquinas: “cola” a la izquierda (bottomStart = 0dp) -->
     <corners
             android:topLeftRadius="16dp"
             android:topRightRadius="16dp"
             android:bottomLeftRadius="0dp"
             android:bottomRightRadius="16dp" />
 
-    <!-- Un poco de padding para que el texto respire -->
+    <stroke
+        android:width="1dp"
+        android:color="@color/colorCardStroke" />
+
     <padding
             android:left="12dp"
             android:top="8dp"

--- a/app/src/main/res/drawable/bubble_outgoing.xml
+++ b/app/src/main/res/drawable/bubble_outgoing.xml
@@ -12,6 +12,10 @@
             android:bottomLeftRadius="16dp"
             android:bottomRightRadius="0dp" />
 
+    <stroke
+            android:width="1dp"
+            android:color="@color/colorCardStroke" />
+
     <padding
             android:left="12dp"
             android:top="8dp"

--- a/app/src/main/res/layout/activity_chat.xml
+++ b/app/src/main/res/layout/activity_chat.xml
@@ -4,6 +4,8 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:animateLayoutChanges="true"
+    android:background="@color/md_theme_light_surfaceContainer"
     android:fitsSystemWindows="true">
 
     <com.google.android.material.appbar.AppBarLayout
@@ -14,28 +16,31 @@
             android:id="@+id/topAppBar"
             style="@style/AppToolbar"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@drawable/bg_gradient_primary"
-            android:theme="@style/ThemeOverlay.Material3.Dark.ActionBar" />
+            android:layout_height="wrap_content" />
     </com.google.android.material.appbar.AppBarLayout>
 
     <com.google.android.material.card.MaterialCardView
         android:id="@+id/messageBanner"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginHorizontal="16dp"
-        android:layout_marginTop="8dp"
+        android:layout_marginHorizontal="20dp"
+        android:layout_marginTop="12dp"
+        android:layout_marginBottom="4dp"
+        android:animateLayoutChanges="true"
         android:visibility="gone"
         app:cardBackgroundColor="?attr/colorSurface"
-        app:cardElevation="4dp"
-        app:shapeAppearanceOverlay="@style/ShapeAppearance.Material3.Corner.Medium">
+        app:cardCornerRadius="20dp"
+        app:cardElevation="0dp"
+        app:strokeColor="@color/colorCardStroke"
+        app:strokeWidth="1dp">
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="center_vertical"
+            android:minHeight="56dp"
             android:orientation="horizontal"
-            android:paddingHorizontal="16dp"
+            android:paddingHorizontal="20dp"
             android:paddingVertical="12dp">
 
             <ImageView
@@ -45,7 +50,7 @@
                 android:contentDescription="@string/chat_banner_icon_content_description"
                 android:padding="4dp"
                 android:src="@drawable/ic_send"
-                android:tint="?attr/colorPrimary" />
+                android:tint="@color/md_theme_light_primary" />
 
             <LinearLayout
                 android:layout_width="0dp"
@@ -54,7 +59,7 @@
                 android:layout_weight="1"
                 android:orientation="vertical">
 
-                <TextView
+                <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/messageBannerTitle"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
@@ -63,7 +68,7 @@
                     android:textAppearance="@style/TextAppearance.Material3.TitleSmall"
                     android:textColor="?attr/colorOnSurface" />
 
-                <TextView
+                <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/messageBannerSubtitle"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
@@ -79,58 +84,84 @@
         android:id="@+id/recyclerView"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1" />
+        android:layout_weight="1"
+        android:layoutAnimation="@anim/layout_fade_through"
+        android:clipToPadding="false"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp" />
 
-    <LinearLayout
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/composerCard"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:padding="8dp">
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginBottom="16dp"
+        android:animateLayoutChanges="true"
+        app:cardBackgroundColor="?attr/colorSurface"
+        app:cardCornerRadius="28dp"
+        app:cardElevation="4dp"
+        app:strokeColor="@color/colorCardStroke"
+        app:strokeWidth="1dp">
 
-        <!-- Botón para seleccionar imagen -->
-        <!-- <com.google.android.material.button.MaterialButton
-            android:id="@+id/buttonSendImage"
-            android:layout_width="wrap_content"
+        <LinearLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="📷" /> -->
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:paddingStart="12dp"
+            android:paddingEnd="12dp"
+            android:paddingTop="8dp"
+            android:paddingBottom="8dp">
 
-        <com.google.android.material.button.MaterialButton
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/buttonSendImage"
+                style="@style/AppButton.Icon"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:contentDescription="@string/chat_add_image"
                 app:icon="@drawable/baseline_add_photo_alternate_24"
-                app:iconGravity="textStart"
-                android:text="" />
+                app:iconTint="?attr/colorOnSurfaceVariant" />
 
-
-        <!-- Campo de texto con TextInputLayout -->
-        <com.google.android.material.textfield.TextInputLayout
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:layout_marginStart="8dp"
-            android:hint="Escribe un mensaje">
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/editMessage"
-                android:layout_width="match_parent"
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:maxLines="4"
-                android:minLines="1"
-                android:inputType="textCapSentences|textMultiLine" />
-        </com.google.android.material.textfield.TextInputLayout>
+                android:layout_marginStart="8dp"
+                android:layout_marginEnd="8dp"
+                android:layout_marginTop="0dp"
+                android:layout_weight="1"
+                style="@style/Widget.Texty.TextInputLayout"
+                app:endIconMode="none"
+                app:startIconDrawable="@drawable/baseline_add_reaction_24"
+                app:startIconTint="@color/text_input_icon">
 
-        <!-- Botón enviar -->
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/buttonSend"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:background="@drawable/bg_gradient_primary"
-            android:text="Enviar"
-            app:icon="@drawable/ic_send"
-            app:iconGravity="textStart"
-            app:iconPadding="0dp"
-            android:layout_marginStart="8dp" />
-    </LinearLayout>
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/editMessage"
+                    style="@style/Widget.Texty.TextInputEditText"
+                    android:hint="@string/chat_message_hint"
+                    android:inputType="textCapSentences|textMultiLine"
+                    android:maxLines="4"
+                    android:minLines="1" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonSend"
+                style="@style/Widget.Material3.Button.Filled"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:minWidth="0dp"
+                android:paddingHorizontal="18dp"
+                android:paddingVertical="10dp"
+                android:text="@string/chat_action_send"
+                android:textAllCaps="false"
+                android:textColor="?attr/colorOnPrimary"
+                app:backgroundTint="@color/md_theme_light_primary"
+                app:icon="@drawable/ic_send"
+                app:iconGravity="textStart"
+                app:iconPadding="8dp"
+                app:iconTint="?attr/colorOnPrimary" />
+        </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
 
 </LinearLayout>

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -3,98 +3,110 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fitsSystemWindows="true"
-    android:fillViewport="true">
+    android:background="@color/md_theme_light_surfaceContainer"
+    android:fillViewport="true"
+    android:fitsSystemWindows="true">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="16dp"
+        android:animateLayoutChanges="true"
+        android:paddingStart="20dp"
+        android:paddingEnd="20dp"
+        android:paddingBottom="32dp"
         android:fitsSystemWindows="true">
 
-        <com.google.android.material.appbar.AppBarLayout
-            android:id="@+id/appBar"
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/topAppBar"
+            style="@style/AppToolbar"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            app:title="@string/login_title"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
+            app:layout_constraintTop_toTopOf="parent" />
 
-            <com.google.android.material.appbar.MaterialToolbar
-                android:id="@+id/topAppBar"
-                style="@style/AppToolbar"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:background="?attr/colorPrimary"
-                android:theme="@style/ThemeOverlay.Material3.Dark.ActionBar" />
-        </com.google.android.material.appbar.AppBarLayout>
-
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/emailLayout"
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/cardContainer"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            app:boxBackgroundMode="outline"
-            app:startIconDrawable="@drawable/ic_email"
-            app:layout_constraintTop_toBottomOf="@id/appBar"
+            android:layout_marginTop="24dp"
+            android:layout_marginBottom="24dp"
+            app:cardBackgroundColor="?attr/colorSurface"
+            app:cardCornerRadius="28dp"
+            app:cardElevation="0dp"
+            app:strokeColor="@color/colorCardStroke"
+            app:strokeWidth="1dp"
+            app:layout_constraintTop_toBottomOf="@id/topAppBar"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent">
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent">
 
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/editEmail"
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="Email"
-                android:inputType="textEmailAddress"
-                android:textColor="?attr/colorOnSecondaryContainer"
-                android:textColorHint="?attr/colorSecondary" />
-        </com.google.android.material.textfield.TextInputLayout>
+                android:orientation="vertical"
+                android:paddingStart="24dp"
+                android:paddingTop="28dp"
+                android:paddingEnd="24dp"
+                android:paddingBottom="32dp">
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/passwordLayout"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            app:boxBackgroundMode="outline"
-            app:startIconDrawable="@drawable/ic_lock"
-            app:layout_constraintTop_toBottomOf="@id/emailLayout"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent">
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/textHeadline"
+                    style="@style/TextAppearance.Texty.Headline"
+                    android:text="@string/login_title" />
 
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/editPassword"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="Password"
-                android:inputType="textPassword"
-                android:textColor="?attr/colorOnSecondaryContainer"
-                android:textColorHint="?attr/colorSecondary" />
-        </com.google.android.material.textfield.TextInputLayout>
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/textSubtitle"
+                    style="@style/TextAppearance.Texty.Body"
+                    android:layout_marginTop="4dp"
+                    android:text="@string/login_subtitle" />
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/buttonLogin"
-            style="@style/AppButton"
-            android:text="Login"
-            app:layout_constraintTop_toBottomOf="@id/passwordLayout"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/emailLayout"
+                    style="@style/Widget.Texty.TextInputLayout"
+                    android:layout_marginTop="24dp"
+                    app:startIconDrawable="@drawable/ic_email">
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/buttonRegister"
-            style="@style/AppButton"
-            android:text="Register"
-            app:layout_constraintTop_toBottomOf="@id/buttonLogin"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/editEmail"
+                        style="@style/Widget.Texty.TextInputEditText"
+                        android:hint="@string/hint_email"
+                        android:inputType="textEmailAddress" />
+                </com.google.android.material.textfield.TextInputLayout>
 
-        <ProgressBar
-            android:id="@+id/progressBar"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:visibility="gone"
-            app:layout_constraintTop_toBottomOf="@id/buttonRegister"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/passwordLayout"
+                    style="@style/Widget.Texty.TextInputLayout"
+                    app:startIconDrawable="@drawable/ic_lock"
+                    app:endIconMode="password_toggle">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/editPassword"
+                        style="@style/Widget.Texty.TextInputEditText"
+                        android:hint="@string/hint_password"
+                        android:inputType="textPassword" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/buttonLogin"
+                    style="@style/AppButton"
+                    android:text="@string/action_login" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/buttonRegister"
+                    style="@style/AppButton.Tonal"
+                    android:text="@string/action_register" />
+
+                <com.google.android.material.progressindicator.CircularProgressIndicator
+                    android:id="@+id/progressBar"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_horizontal"
+                    android:layout_marginTop="16dp"
+                    android:visibility="gone" />
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </ScrollView>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,41 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:animateLayoutChanges="true"
+    android:background="@color/md_theme_light_surfaceContainer">
 
     <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:background="@drawable/bg_gradient_primary"
-            android:titleTextColor="?attr/colorOnPrimary"
-            app:title="@string/app_name"
-            app:navigationIconTint="?attr/colorOnPrimary"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+        android:id="@+id/toolbar"
+        style="@style/AppToolbar"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:title="@string/app_name"
+        app:navigationIconTint="?attr/colorOnPrimary"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
 
-    <!-- MANTENEMOS EL ID QUE YA USA TU KOTLIN -->
     <FrameLayout
-            android:id="@+id/fragmentContainer"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            app:layout_constraintTop_toBottomOf="@id/toolbar"
-            app:layout_constraintBottom_toTopOf="@id/bottomNavigation"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+        android:id="@+id/fragmentContainer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:animateLayoutChanges="true"
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp"
+        app:layout_constraintTop_toBottomOf="@id/toolbar"
+        app:layout_constraintBottom_toTopOf="@id/bottomNavigation"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
 
-    <!-- Usa BottomNavigationView (Material 3), pero con el ID antiguo -->
     <com.google.android.material.bottomnavigation.BottomNavigationView
-            android:id="@+id/bottomNavigation"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:background="?attr/colorSurface"
-            app:menu="@menu/menu_bottom_nav"
-            style="@style/Widget.Material3.BottomNavigationView"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+        android:id="@+id/bottomNavigation"
+        style="@style/Widget.Material3.BottomNavigationView"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorSurface"
+        android:paddingTop="4dp"
+        android:paddingBottom="4dp"
+        app:menu="@menu/menu_bottom_nav"
+        app:itemIconTint="@color/bottom_nav_colors"
+        app:itemTextColor="@color/bottom_nav_colors"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_register.xml
+++ b/app/src/main/res/layout/activity_register.xml
@@ -3,13 +3,17 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fitsSystemWindows="true"
-    android:fillViewport="true">
+    android:background="@color/md_theme_light_surfaceContainer"
+    android:fillViewport="true"
+    android:fitsSystemWindows="true">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="16dp"
+        android:animateLayoutChanges="true"
+        android:paddingStart="20dp"
+        android:paddingEnd="20dp"
+        android:paddingBottom="32dp"
         android:fitsSystemWindows="true">
 
         <com.google.android.material.appbar.MaterialToolbar
@@ -17,82 +21,91 @@
             style="@style/AppToolbar"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:background="?attr/colorPrimary"
-            android:theme="@style/ThemeOverlay.Material3.Dark.ActionBar"
-            app:title="@string/register_title"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent"
+            app:title="@string/register_title" />
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/nameLayout"
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/cardContainer"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            app:boxBackgroundMode="outline"
-            app:startIconDrawable="@drawable/ic_person"
+            android:layout_marginTop="24dp"
+            android:layout_marginBottom="24dp"
+            app:cardBackgroundColor="?attr/colorSurface"
+            app:cardCornerRadius="28dp"
+            app:cardElevation="0dp"
+            app:strokeColor="@color/colorCardStroke"
+            app:strokeWidth="1dp"
             app:layout_constraintTop_toBottomOf="@id/topAppBar"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent">
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent">
 
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/editName"
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="Name"
-                android:textColor="?attr/colorOnSecondaryContainer"
-                android:textColorHint="?attr/colorSecondary" />
-        </com.google.android.material.textfield.TextInputLayout>
+                android:orientation="vertical"
+                android:paddingStart="24dp"
+                android:paddingTop="28dp"
+                android:paddingEnd="24dp"
+                android:paddingBottom="32dp">
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/emailLayout"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            app:boxBackgroundMode="outline"
-            app:startIconDrawable="@drawable/ic_email"
-            app:layout_constraintTop_toBottomOf="@id/nameLayout"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent">
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/textHeadline"
+                    style="@style/TextAppearance.Texty.Headline"
+                    android:text="@string/register_title" />
 
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/editEmail"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="Email"
-                android:inputType="textEmailAddress"
-                android:textColor="?attr/colorOnSecondaryContainer"
-                android:textColorHint="?attr/colorSecondary" />
-        </com.google.android.material.textfield.TextInputLayout>
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/textSubtitle"
+                    style="@style/TextAppearance.Texty.Body"
+                    android:layout_marginTop="4dp"
+                    android:text="@string/register_subtitle" />
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/passwordLayout"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            app:boxBackgroundMode="outline"
-            app:startIconDrawable="@drawable/ic_lock"
-            app:layout_constraintTop_toBottomOf="@id/emailLayout"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent">
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/nameLayout"
+                    style="@style/Widget.Texty.TextInputLayout"
+                    android:layout_marginTop="24dp"
+                    app:startIconDrawable="@drawable/ic_person">
 
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/editPassword"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="Password"
-                android:inputType="textPassword"
-                android:textColor="?attr/colorOnSecondaryContainer"
-                android:textColorHint="?attr/colorSecondary" />
-        </com.google.android.material.textfield.TextInputLayout>
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/editName"
+                        style="@style/Widget.Texty.TextInputEditText"
+                        android:hint="@string/hint_name"
+                        android:inputType="textCapWords" />
+                </com.google.android.material.textfield.TextInputLayout>
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/buttonRegister"
-            style="@style/AppButton"
-            android:text="Register"
-            app:layout_constraintTop_toBottomOf="@id/passwordLayout"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/emailLayout"
+                    style="@style/Widget.Texty.TextInputLayout"
+                    app:startIconDrawable="@drawable/ic_email">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/editEmail"
+                        style="@style/Widget.Texty.TextInputEditText"
+                        android:hint="@string/hint_email"
+                        android:inputType="textEmailAddress" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/passwordLayout"
+                    style="@style/Widget.Texty.TextInputLayout"
+                    app:startIconDrawable="@drawable/ic_lock"
+                    app:endIconMode="password_toggle">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/editPassword"
+                        style="@style/Widget.Texty.TextInputEditText"
+                        android:hint="@string/hint_password"
+                        android:inputType="textPassword" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/buttonRegister"
+                    style="@style/AppButton"
+                    android:text="@string/action_register" />
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </ScrollView>

--- a/app/src/main/res/layout/fragment_chat_list.xml
+++ b/app/src/main/res/layout/fragment_chat_list.xml
@@ -3,6 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:animateLayoutChanges="true"
+    android:background="@color/md_theme_light_surfaceContainer"
     android:fitsSystemWindows="true">
 
     <com.google.android.material.appbar.MaterialToolbar
@@ -10,22 +12,17 @@
         style="@style/AppToolbar"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:background="?attr/colorPrimary"
-        android:theme="@style/ThemeOverlay.Material3.Dark.ActionBar"
+        app:title="@string/chats_title"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:title="@string/chats_title" />
-
-
+        app:layout_constraintTop_toTopOf="parent" />
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/searchLayout"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="8dp"
-        android:layout_marginEnd="16dp"
+        style="@style/Widget.Texty.TextInputLayout"
+        android:layout_marginStart="20dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="20dp"
         app:startIconDrawable="@drawable/ic_search"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -33,45 +30,67 @@
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/editSearch"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="@string/search_hint" />
-
+            style="@style/Widget.Texty.TextInputEditText"
+            android:hint="@string/search_hint"
+            android:imeOptions="actionSearch"
+            android:inputType="text" />
     </com.google.android.material.textfield.TextInputLayout>
 
-    <FrameLayout
-        android:id="@+id/contentContainer"
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/cardContent"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="8dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginBottom="16dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginStart="20dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="20dp"
+        android:layout_marginBottom="20dp"
+        android:animateLayoutChanges="true"
+        app:cardBackgroundColor="?attr/colorSurface"
+        app:cardCornerRadius="28dp"
+        app:cardElevation="0dp"
+        app:strokeColor="@color/colorCardStroke"
+        app:strokeWidth="1dp"
+        app:layout_constraintTop_toBottomOf="@id/searchLayout"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/searchLayout">
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent">
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/recyclerChats"
+        <FrameLayout
+            android:id="@+id/contentContainer"
             android:layout_width="match_parent"
-            android:layout_height="match_parent" />
+            android:layout_height="match_parent"
+            android:animateLayoutChanges="true"
+            android:padding="8dp">
 
-        <TextView
-            android:id="@+id/textPlaceholder"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:text="@string/no_chats_placeholder"
-            android:visibility="gone" />
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recyclerChats"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:clipToPadding="false"
+                android:paddingStart="8dp"
+                android:paddingEnd="8dp"
+                android:paddingTop="4dp"
+                android:paddingBottom="4dp"
+                android:layoutAnimation="@anim/layout_fade_through" />
 
-        <ProgressBar
-            android:id="@+id/progressBar"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:visibility="gone" />
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/textPlaceholder"
+                style="@style/TextAppearance.Texty.Body"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:gravity="center"
+                android:padding="24dp"
+                android:text="@string/no_chats_placeholder"
+                android:visibility="gone" />
 
-    </FrameLayout>
+            <com.google.android.material.progressindicator.CircularProgressIndicator
+                android:id="@+id/progressBar"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:visibility="gone" />
+        </FrameLayout>
+    </com.google.android.material.card.MaterialCardView>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -2,14 +2,16 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:animateLayoutChanges="true"
+    android:background="@color/md_theme_light_surfaceContainer">
 
     <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/profileToolbar"
+        style="@style/AppToolbar"
         android:layout_width="0dp"
-        android:layout_height="?attr/actionBarSize"
-        android:background="@drawable/bg_gradient_primary"
-        android:title="@string/profile_title"
+        android:layout_height="wrap_content"
+        app:title="@string/profile_title"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
@@ -18,6 +20,10 @@
         android:id="@+id/profileScroll"
         android:layout_width="0dp"
         android:layout_height="0dp"
+        android:animateLayoutChanges="true"
+        android:paddingStart="20dp"
+        android:paddingEnd="20dp"
+        android:paddingBottom="24dp"
         app:layout_constraintTop_toBottomOf="@id/profileToolbar"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -26,65 +32,73 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:gravity="center_horizontal"
             android:orientation="vertical"
-            android:padding="16dp"
-            android:gravity="center_horizontal">
+            android:paddingTop="24dp"
+            android:paddingBottom="8dp">
 
             <com.google.android.material.card.MaterialCardView
                 android:id="@+id/cardProfile"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="16dp"
-                app:cardElevation="4dp">
+                android:layout_marginBottom="20dp"
+                android:animateLayoutChanges="true"
+                app:cardBackgroundColor="?attr/colorSurface"
+                app:cardCornerRadius="28dp"
+                app:cardElevation="0dp"
+                app:strokeColor="@color/colorCardStroke"
+                app:strokeWidth="1dp">
 
                 <androidx.constraintlayout.widget.ConstraintLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:padding="16dp">
+                    android:padding="24dp">
 
                     <com.google.android.material.imageview.ShapeableImageView
                         android:id="@+id/imageProfile"
                         android:layout_width="120dp"
                         android:layout_height="120dp"
-                        android:src="@drawable/ic_person"
                         android:contentDescription="@string/profile_photo"
-                        app:layout_constraintTop_toTopOf="parent"
+                        android:scaleType="centerCrop"
+                        android:src="@drawable/ic_person"
                         app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:shapeAppearanceOverlay="@style/ShapeAppearance.Material3.Corner.Full" />
 
                     <com.google.android.material.button.MaterialButton
                         android:id="@+id/buttonEdit"
-                        style="?attr/materialIconButtonStyle"
+                        style="@style/AppButton.Icon"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:contentDescription="@string/edit"
                         android:icon="@drawable/ic_edit"
-                        app:layout_constraintTop_toTopOf="parent"
-                        app:layout_constraintEnd_toEndOf="parent" />
+                        app:iconTint="@color/md_theme_light_primary"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
 
                     <com.google.android.material.textfield.TextInputLayout
                         android:id="@+id/nameLayout"
+                        style="@style/Widget.Texty.TextInputLayout"
                         android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="16dp"
+                        android:layout_marginTop="24dp"
                         app:layout_constraintTop_toBottomOf="@id/imageProfile"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintEnd_toEndOf="parent">
 
                         <com.google.android.material.textfield.TextInputEditText
                             android:id="@+id/editDisplayName"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
+                            style="@style/Widget.Texty.TextInputEditText"
                             android:hint="@string/display_name" />
                     </com.google.android.material.textfield.TextInputLayout>
 
                     <com.google.android.material.textview.MaterialTextView
                         android:id="@+id/textUserEmail"
+                        style="@style/TextAppearance.Texty.Body"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="16dp"
-                        style="?attr/textAppearanceBodyMedium"
+                        android:layout_marginTop="20dp"
+                        android:gravity="center"
                         app:layout_constraintTop_toBottomOf="@id/nameLayout"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintEnd_toEndOf="parent" />
@@ -94,31 +108,29 @@
 
             <com.google.android.material.textfield.TextInputLayout
                 android:id="@+id/aboutLayout"
+                style="@style/Widget.Texty.TextInputLayout"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="16dp">
+                android:layout_marginBottom="20dp">
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/editAbout"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
+                    style="@style/Widget.Texty.TextInputEditText"
+                    android:gravity="top|start"
                     android:hint="@string/profile_about"
                     android:inputType="textMultiLine"
-                    android:minLines="3"
-                    android:gravity="top|start" />
+                    android:minLines="3" />
 
             </com.google.android.material.textfield.TextInputLayout>
 
             <com.google.android.material.textfield.TextInputLayout
                 android:id="@+id/phoneLayout"
+                style="@style/Widget.Texty.TextInputLayout"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="16dp">
+                android:layout_marginBottom="20dp">
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/editPhone"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
+                    style="@style/Widget.Texty.TextInputEditText"
                     android:hint="@string/profile_phone"
                     android:inputType="phone" />
 
@@ -128,24 +140,30 @@
                 android:id="@+id/cardNotifications"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="16dp"
-                app:cardElevation="4dp">
+                android:layout_marginBottom="20dp"
+                android:animateLayoutChanges="true"
+                app:cardBackgroundColor="?attr/colorSurface"
+                app:cardCornerRadius="24dp"
+                app:cardElevation="0dp"
+                app:strokeColor="@color/colorCardStroke"
+                app:strokeWidth="1dp">
 
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="vertical"
-                    android:padding="16dp">
+                    android:padding="20dp">
 
                     <com.google.android.material.textview.MaterialTextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
+                        style="@style/TextAppearance.Material3.TitleSmall"
                         android:text="@string/notifications" />
 
                     <com.google.android.material.materialswitch.MaterialSwitch
                         android:id="@+id/switchNotifications"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
+                        android:layout_marginTop="12dp"
+                        android:fontFamily="sans-serif"
                         android:text="@string/enable_notifications" />
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>
@@ -154,24 +172,30 @@
                 android:id="@+id/cardPrivacy"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="16dp"
-                app:cardElevation="4dp">
+                android:layout_marginBottom="20dp"
+                android:animateLayoutChanges="true"
+                app:cardBackgroundColor="?attr/colorSurface"
+                app:cardCornerRadius="24dp"
+                app:cardElevation="0dp"
+                app:strokeColor="@color/colorCardStroke"
+                app:strokeWidth="1dp">
 
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="vertical"
-                    android:padding="16dp">
+                    android:padding="20dp">
 
                     <com.google.android.material.textview.MaterialTextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
+                        style="@style/TextAppearance.Material3.TitleSmall"
                         android:text="@string/privacy" />
 
                     <com.google.android.material.materialswitch.MaterialSwitch
                         android:id="@+id/switchPrivacy"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
+                        android:layout_marginTop="12dp"
+                        android:fontFamily="sans-serif"
                         android:text="@string/private_account" />
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>
@@ -179,25 +203,16 @@
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/buttonSave"
                 style="@style/AppButton.Tonal"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="16dp"
                 android:text="@string/save" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/buttonChangePassword"
                 style="@style/AppButton.Outlined"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="16dp"
                 android:text="@string/change_password" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/buttonLogout"
                 style="@style/AppButton.Outlined"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="16dp"
                 android:text="@string/logout" />
 
         </LinearLayout>

--- a/app/src/main/res/layout/item_chat.xml
+++ b/app/src/main/res/layout/item_chat.xml
@@ -1,87 +1,96 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
-                                                   xmlns:app="http://schemas.android.com/apk/res-auto"
-                                                   style="?attr/materialCardViewStyle"
-                                                   android:layout_width="match_parent"
-                                                   android:layout_height="wrap_content">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    style="?attr/materialCardViewStyle"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="12dp"
+    android:foreground="?attr/selectableItemBackground"
+    app:cardBackgroundColor="?attr/colorSurface"
+    app:cardCornerRadius="24dp"
+    app:cardElevation="0dp"
+    app:strokeColor="@color/colorCardStroke"
+    app:strokeWidth="1dp">
 
     <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:padding="16dp">
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="16dp">
 
         <FrameLayout
-                android:layout_width="40dp"
-                android:layout_height="40dp"
-                android:layout_marginEnd="16dp">
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_marginEnd="16dp">
 
             <com.google.android.material.imageview.ShapeableImageView
-                    android:id="@+id/imageAvatar"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:src="@mipmap/ic_launcher"
-                    android:contentDescription="@null"
-                    app:shapeAppearanceOverlay="@style/ShapeAppearance.Material3.Corner.Full" />
+                android:id="@+id/imageAvatar"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:contentDescription="@null"
+                android:scaleType="centerCrop"
+                android:src="@mipmap/ic_launcher"
+                app:shapeAppearanceOverlay="@style/ShapeAppearance.Material3.Corner.Full" />
 
             <View
-                    android:id="@+id/viewStatus"
-                    style="@style/StateDot.Error"
-                    android:layout_gravity="bottom|end" />
+                android:id="@+id/viewStatus"
+                style="@style/StateDot.Error"
+                android:layout_gravity="bottom|end" />
         </FrameLayout>
 
         <LinearLayout
-                android:layout_width="0dp"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/textName"
+                style="@style/TextAppearance.Material3.TitleMedium"
+                android:textColor="?attr/colorOnSurface" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/textLastMessage"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:layout_weight="1">
-
-            <TextView
-                    android:id="@+id/textName"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:textSize="16sp"
-                    android:textStyle="bold" />
-
-            <TextView
-                    android:id="@+id/textLastMessage"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:ellipsize="end"
-                    android:maxLines="1"
-                    android:visibility="gone" />
+                android:ellipsize="end"
+                android:maxLines="1"
+                android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+                android:textColor="?attr/colorOnSurfaceVariant"
+                android:visibility="gone" />
         </LinearLayout>
 
         <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:gravity="end"
+            android:orientation="vertical"
+            android:layout_marginStart="8dp"
+            android:layout_gravity="center_vertical">
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/textLastUpdated"
                 android:layout_width="wrap_content"
-                android:layout_height="match_parent"
+                android:layout_height="wrap_content"
                 android:gravity="end"
-                android:orientation="vertical"
-                android:layout_marginStart="8dp"
-                android:layout_gravity="center_vertical">
+                android:textAppearance="@style/TextAppearance.Material3.LabelSmall"
+                android:textColor="?attr/colorOnSurfaceVariant"
+                android:visibility="gone" />
 
-            <TextView
-                    android:id="@+id/textLastUpdated"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:gravity="end"
-                    android:textColor="@color/md_theme_light_success"
-                    android:textSize="12sp"
-                    android:visibility="gone" />
-
-            <TextView
-                    android:id="@+id/textUnreadCount"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:minWidth="24dp"
-                    android:minHeight="24dp"
-                    android:gravity="center"
-                    android:background="@drawable/unread_badge"
-                    android:textColor="@android:color/white"
-                    android:textStyle="bold"
-                    android:visibility="gone"
-                    android:layout_marginTop="4dp"
-                    android:layout_gravity="end"/>
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/textUnreadCount"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end"
+                android:layout_marginTop="4dp"
+                android:background="@drawable/unread_badge"
+                android:gravity="center"
+                android:minHeight="24dp"
+                android:minWidth="24dp"
+                android:paddingHorizontal="8dp"
+                android:textColor="@android:color/white"
+                android:textStyle="bold"
+                android:visibility="gone" />
         </LinearLayout>
     </LinearLayout>
 

--- a/app/src/main/res/layout/item_message.xml
+++ b/app/src/main/res/layout/item_message.xml
@@ -3,37 +3,40 @@
     android:id="@+id/messageRoot"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:animateLayoutChanges="true"
+    android:gravity="start"
     android:orientation="vertical"
-    android:padding="8dp"
-    android:gravity="start">
+    android:paddingHorizontal="8dp"
+    android:paddingVertical="6dp">
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/textMessage"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:padding="8dp"
-        android:textColor="@android:color/black"
+        android:maxWidth="280dp"
+        android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
+        android:textColor="?attr/colorOnSurface"
         android:background="@drawable/bubble_incoming"
         android:foreground="?attr/selectableItemBackgroundBorderless" />
 
     <ImageView
-            android:id="@+id/imageMessage"
-            android:layout_width="200dp"
-            android:layout_height="200dp"
-            android:scaleType="centerCrop"
-            android:adjustViewBounds="true"
-            android:layout_marginTop="4dp"
-            android:visibility="gone"
-            android:background="@drawable/bubble_incoming"
-            android:foreground="?attr/selectableItemBackgroundBorderless" />
+        android:id="@+id/imageMessage"
+        android:layout_width="220dp"
+        android:layout_height="220dp"
+        android:layout_marginTop="6dp"
+        android:adjustViewBounds="true"
+        android:background="@drawable/bubble_incoming"
+        android:foreground="?attr/selectableItemBackgroundBorderless"
+        android:contentDescription="@null"
+        android:scaleType="centerCrop"
+        android:visibility="gone" />
 
-
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/textTime"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
-        android:textColor="@android:color/darker_gray"
-        android:textSize="12sp" />
+        android:layout_marginTop="6dp"
+        android:textAppearance="@style/TextAppearance.Material3.LabelSmall"
+        android:textColor="?attr/colorOnSurfaceVariant" />
 
 </LinearLayout>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,18 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="md_theme_light_primary">#6366F1</color>
+    <color name="md_theme_light_onPrimary">#FFFFFF</color>
+    <color name="md_theme_light_primaryContainer">#312E81</color>
+    <color name="md_theme_light_onPrimaryContainer">#E0E7FF</color>
+
     <color name="md_theme_light_secondary">#22D3EE</color>
+    <color name="md_theme_light_onSecondary">#042F2E</color>
+    <color name="md_theme_light_secondaryContainer">#164E63</color>
+    <color name="md_theme_light_onSecondaryContainer">#ECFEFF</color>
+
     <color name="md_theme_light_tertiary">#FF6B6B</color>
     <color name="md_theme_light_surface">#111827</color>
     <color name="md_theme_light_surfaceVariant">#1E293B</color>
+    <color name="md_theme_light_surfaceContainer">#0B1120</color>
     <color name="md_theme_light_onSurface">#F1F5F9</color>
     <color name="md_theme_light_onSurfaceVariant">#9CA3AF</color>
+    <color name="md_theme_light_outline">#334155</color>
+    <color name="md_theme_light_outlineVariant">#1F2937</color>
     <color name="md_theme_light_error">#EF4444</color>
     <color name="md_theme_light_warning">#F59E0B</color>
     <color name="md_theme_light_success">#22C55E</color>
-    <color name="md_theme_light_onPrimary">#FFFFFF</color>
+
     <color name="colorSuccess">#22C55E</color>
     <color name="colorWarning">#F59E0B</color>
     <color name="colorError">#EF4444</color>
     <color name="colorInfo">#60A5FA</color>
+
+    <color name="colorCardStroke">#1F2937</color>
 </resources>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -3,14 +3,34 @@
     <!-- Tema base (night) con Material 3 -->
     <style name="Base.Theme.Texty" parent="Theme.Material3.DayNight.NoActionBar">
         <item name="colorPrimary">@color/md_theme_light_primary</item>
+        <item name="colorOnPrimary">@color/md_theme_light_onPrimary</item>
+        <item name="colorPrimaryContainer">@color/md_theme_light_primaryContainer</item>
+        <item name="colorOnPrimaryContainer">@color/md_theme_light_onPrimaryContainer</item>
+
         <item name="colorSecondary">@color/md_theme_light_secondary</item>
+        <item name="colorOnSecondary">@color/md_theme_light_onSecondary</item>
+        <item name="colorSecondaryContainer">@color/md_theme_light_secondaryContainer</item>
+        <item name="colorOnSecondaryContainer">@color/md_theme_light_onSecondaryContainer</item>
+
         <item name="colorTertiary">@color/md_theme_light_tertiary</item>
         <item name="colorSurface">@color/md_theme_light_surface</item>
         <item name="colorSurfaceVariant">@color/md_theme_light_surfaceVariant</item>
         <item name="colorOnSurface">@color/md_theme_light_onSurface</item>
         <item name="colorOnSurfaceVariant">@color/md_theme_light_onSurfaceVariant</item>
+        <item name="colorOutline">@color/md_theme_light_outline</item>
+        <item name="colorOutlineVariant">@color/md_theme_light_outlineVariant</item>
         <item name="colorError">@color/md_theme_light_error</item>
-        <item name="colorOnPrimary">@color/md_theme_light_onPrimary</item>
+
+        <item name="android:windowBackground">@color/md_theme_light_surfaceContainer</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@color/md_theme_light_surface</item>
+        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:windowLightNavigationBar">false</item>
+        <item name="android:fontFamily">sans-serif</item>
+
+        <item name="toolbarStyle">@style/AppToolbar</item>
+        <item name="textInputStyle">@style/Widget.Texty.TextInputLayout</item>
+        <item name="textInputEditTextStyle">@style/Widget.Texty.TextInputEditText</item>
     </style>
 
     <!-- Alias del tema de la app (igual que en values/) -->

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,20 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="md_theme_light_primary">#6366F1</color>
+    <color name="md_theme_light_onPrimary">#FFFFFF</color>
+    <color name="md_theme_light_primaryContainer">#E0E7FF</color>
+    <color name="md_theme_light_onPrimaryContainer">#1E1B4B</color>
+
     <color name="md_theme_light_secondary">#22D3EE</color>
+    <color name="md_theme_light_onSecondary">#042F2E</color>
+    <color name="md_theme_light_secondaryContainer">#CFFAFE</color>
+    <color name="md_theme_light_onSecondaryContainer">#083344</color>
+
     <color name="md_theme_light_tertiary">#FF6B6B</color>
     <color name="md_theme_light_surface">#FFFFFF</color>
     <color name="md_theme_light_surfaceVariant">#F2F4F8</color>
+    <color name="md_theme_light_surfaceContainer">#F8FAFF</color>
     <color name="md_theme_light_onSurface">#0F172A</color>
     <color name="md_theme_light_onSurfaceVariant">#6B7280</color>
+    <color name="md_theme_light_outline">#D0D5DD</color>
+    <color name="md_theme_light_outlineVariant">#E2E8F0</color>
     <color name="md_theme_light_error">#EF4444</color>
     <color name="md_theme_light_warning">#F59E0B</color>
     <color name="md_theme_light_success">#22C55E</color>
-    <color name="md_theme_light_onPrimary">#FFFFFF</color>
+
     <color name="colorSuccess">#22C55E</color>
     <color name="colorWarning">#F59E0B</color>
     <color name="colorError">#EF4444</color>
     <color name="colorInfo">#3B82F6</color>
+
+    <color name="colorCardStroke">#E3E8F2</color>
+
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,13 @@
     <string name="required_field">Campo requerido</string>
     <string name="logout">Cerrar sesión</string>
     <string name="save">Guardar</string>
+    <string name="action_login">Iniciar sesión</string>
+    <string name="action_register">Crear cuenta</string>
+    <string name="login_subtitle">Gestiona tus conversaciones seguras</string>
+    <string name="register_subtitle">Crea tu cuenta para comenzar a chatear</string>
+    <string name="hint_email">Correo electrónico</string>
+    <string name="hint_password">Contraseña</string>
+    <string name="hint_name">Nombre completo</string>
     <string name="display_name">Nombre</string>
     <string name="profile_photo">Foto de perfil</string>
     <string name="chats_title">Chats</string>
@@ -42,6 +49,9 @@
     <string name="chat_banner_icon_content_description">Mensaje enviado</string>
     <string name="chat_banner_message_sent">Mensaje enviado</string>
     <string name="chat_banner_preview_with_time">%1$s · %2$s</string>
+    <string name="chat_add_image">Adjuntar imagen</string>
+    <string name="chat_message_hint">Escribe un mensaje</string>
+    <string name="chat_action_send">Enviar</string>
     <string name="notification_generic_title">Nuevo mensaje</string>
     <string name="notification_generic_body">Tienes un mensaje nuevo</string>
     <plurals name="notification_new_messages">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,24 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <!-- Text field base style -->
-    <style name="AppEditText" parent="Widget.AppCompat.EditText">
-        <item name="android:layout_width">match_parent</item>
-        <item name="android:layout_height">wrap_content</item>
-        <item name="android:layout_marginTop">16dp</item>
-        <item name="android:padding">16dp</item>
-        <item name="android:backgroundTint">?attr/colorSurfaceVariant</item>
-        <item name="android:textColor">?attr/colorOnSurface</item>
-        <item name="android:textColorHint">?attr/colorTertiary</item>
+    <style name="AppToolbar" parent="Widget.Material3.Toolbar">
+        <item name="android:background">@drawable/bg_gradient_primary</item>
+        <item name="titleTextColor">@color/md_theme_light_onPrimary</item>
+        <item name="subtitleTextColor">@color/md_theme_light_onPrimary</item>
+        <item name="android:popupTheme">@style/ThemeOverlay.Material3.Light</item>
+        <item name="android:elevation">0dp</item>
+        <item name="navigationIconTint">@color/md_theme_light_onPrimary</item>
     </style>
 
-    <!-- Material 3 Buttons -->
+    <style name="AppToolbar.Surface" parent="AppToolbar">
+        <item name="android:background">@color/md_theme_light_surface</item>
+        <item name="titleTextColor">@color/md_theme_light_onSurface</item>
+        <item name="subtitleTextColor">@color/md_theme_light_onSurfaceVariant</item>
+        <item name="navigationIconTint">@color/md_theme_light_onSurface</item>
+    </style>
+
     <style name="AppButton" parent="Widget.Material3.Button">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
-        <item name="android:layout_marginTop">16dp</item>
-        <item name="android:padding">16dp</item>
-        <!-- Use the theme token for M3 shape -->
+        <item name="android:layout_marginTop">20dp</item>
+        <item name="android:paddingTop">14dp</item>
+        <item name="android:paddingBottom">14dp</item>
+        <item name="android:textAllCaps">false</item>
+        <item name="android:fontFamily">sans-serif-medium</item>
+        <item name="android:letterSpacing">0.02</item>
         <item name="shapeAppearance">?attr/shapeAppearanceMediumComponent</item>
     </style>
 
@@ -26,7 +33,11 @@
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_marginTop">16dp</item>
-        <item name="android:padding">16dp</item>
+        <item name="android:paddingTop">14dp</item>
+        <item name="android:paddingBottom">14dp</item>
+        <item name="android:textAllCaps">false</item>
+        <item name="android:fontFamily">sans-serif-medium</item>
+        <item name="android:letterSpacing">0.02</item>
         <item name="shapeAppearance">?attr/shapeAppearanceMediumComponent</item>
     </style>
 
@@ -34,14 +45,57 @@
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_marginTop">16dp</item>
-        <item name="android:padding">16dp</item>
+        <item name="android:paddingTop">14dp</item>
+        <item name="android:paddingBottom">14dp</item>
+        <item name="android:textAllCaps">false</item>
+        <item name="android:fontFamily">sans-serif-medium</item>
+        <item name="android:letterSpacing">0.02</item>
         <item name="shapeAppearance">?attr/shapeAppearanceMediumComponent</item>
     </style>
 
-    <!-- Toolbar -->
-    <style name="AppToolbar" parent="Widget.Material3.Toolbar" />
+    <style name="AppButton.Icon" parent="Widget.Material3.Button.Icon">
+        <item name="android:padding">10dp</item>
+        <item name="android:layout_marginStart">0dp</item>
+        <item name="android:layout_marginEnd">8dp</item>
+        <item name="backgroundTint">@color/md_theme_light_surfaceVariant</item>
+        <item name="shapeAppearance">?attr/shapeAppearanceLargeComponent</item>
+    </style>
 
-    <!-- Punto base -->
+    <style name="Widget.Texty.TextInputLayout" parent="Widget.Material3.TextInputLayout.OutlinedBox">
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_marginTop">16dp</item>
+        <item name="boxBackgroundMode">outline</item>
+        <item name="boxStrokeWidth">1dp</item>
+        <item name="boxStrokeWidthFocused">2dp</item>
+        <item name="boxStrokeColor">@color/text_input_stroke</item>
+        <item name="boxBackgroundColor">@color/md_theme_light_surfaceVariant</item>
+        <item name="hintTextColor">@color/text_input_hint</item>
+        <item name="android:hintTextColor">@color/text_input_hint</item>
+        <item name="startIconTint">@color/text_input_icon</item>
+        <item name="endIconTint">@color/text_input_icon</item>
+        <item name="shapeAppearance">@style/ShapeAppearance.Material3.Corner.Medium</item>
+    </style>
+
+    <style name="Widget.Texty.TextInputEditText" parent="Widget.Material3.TextInputEditText.OutlinedBox">
+        <item name="android:paddingTop">16dp</item>
+        <item name="android:paddingBottom">16dp</item>
+        <item name="android:textColor">?attr/colorOnSurface</item>
+        <item name="android:textColorHint">@color/text_input_hint</item>
+        <item name="android:fontFamily">sans-serif</item>
+        <item name="android:textSize">16sp</item>
+    </style>
+
+    <style name="TextAppearance.Texty.Headline" parent="TextAppearance.Material3.TitleLarge">
+        <item name="android:textColor">?attr/colorOnSurface</item>
+        <item name="android:fontFamily">sans-serif-medium</item>
+    </style>
+
+    <style name="TextAppearance.Texty.Body" parent="TextAppearance.Material3.BodyMedium">
+        <item name="android:textColor">?attr/colorOnSurfaceVariant</item>
+        <item name="android:fontFamily">sans-serif</item>
+    </style>
+
     <style name="StateDot">
         <item name="android:layout_width">8dp</item>
         <item name="android:layout_height">8dp</item>
@@ -49,15 +103,14 @@
         <item name="android:layout_marginEnd">6dp</item>
     </style>
 
-    <!-- Variante de error (la que te falta) -->
     <style name="StateDot.Error" parent="StateDot">
         <item name="android:background">@drawable/state_dot_error</item>
     </style>
 
-    <!-- (Opcional, por si el layout usa otras variantes) -->
     <style name="StateDot.Online" parent="StateDot">
         <item name="android:background">@drawable/state_dot_online</item>
     </style>
+
     <style name="StateDot.Offline" parent="StateDot">
         <item name="android:background">@drawable/state_dot_offline</item>
     </style>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -3,19 +3,35 @@
 
     <!-- Base application theme using Material 3 -->
     <style name="Base.Theme.Texty" parent="Theme.Material3.DayNight.NoActionBar">
-        <!-- Colores principales de tu app -->
         <item name="colorPrimary">@color/md_theme_light_primary</item>
+        <item name="colorOnPrimary">@color/md_theme_light_onPrimary</item>
+        <item name="colorPrimaryContainer">@color/md_theme_light_primaryContainer</item>
+        <item name="colorOnPrimaryContainer">@color/md_theme_light_onPrimaryContainer</item>
+
         <item name="colorSecondary">@color/md_theme_light_secondary</item>
+        <item name="colorOnSecondary">@color/md_theme_light_onSecondary</item>
+        <item name="colorSecondaryContainer">@color/md_theme_light_secondaryContainer</item>
+        <item name="colorOnSecondaryContainer">@color/md_theme_light_onSecondaryContainer</item>
+
         <item name="colorTertiary">@color/md_theme_light_tertiary</item>
         <item name="colorSurface">@color/md_theme_light_surface</item>
         <item name="colorSurfaceVariant">@color/md_theme_light_surfaceVariant</item>
         <item name="colorOnSurface">@color/md_theme_light_onSurface</item>
         <item name="colorOnSurfaceVariant">@color/md_theme_light_onSurfaceVariant</item>
+        <item name="colorOutline">@color/md_theme_light_outline</item>
+        <item name="colorOutlineVariant">@color/md_theme_light_outlineVariant</item>
         <item name="colorError">@color/md_theme_light_error</item>
 
-        <!-- Contraste sobre colorPrimary (botones/toolbar) -->
-        <item name="colorOnPrimary">@color/md_theme_light_onPrimary</item>
+        <item name="android:windowBackground">@color/md_theme_light_surfaceContainer</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@color/md_theme_light_surface</item>
+        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:windowLightNavigationBar">true</item>
+        <item name="android:fontFamily">sans-serif</item>
+
         <item name="toolbarStyle">@style/AppToolbar</item>
+        <item name="textInputStyle">@style/Widget.Texty.TextInputLayout</item>
+        <item name="textInputEditTextStyle">@style/Widget.Texty.TextInputEditText</item>
     </style>
 
     <!-- Tema de la app -->


### PR DESCRIPTION
## Summary
- refresh the Material 3 theme tokens and shared styles to provide consistent typography, color containers, and text field states
- redesign the authentication, chat, profile, and main navigation layouts with elevated cards, improved spacing, and updated strings
- add fade-through list animations and align chat bubble visuals, including attachment backgrounds, with the updated palette

## Testing
- `./gradlew lint` *(fails: unable to download Gradle wrapper because of proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d385dc69ac8320b3c47c423cdbc744