### PR TITLE
Fix resource theme attrs causing assemble failure

### DIFF
--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -30,7 +30,6 @@
 
         <item name="toolbarStyle">@style/AppToolbar</item>
         <item name="textInputStyle">@style/Widget.Texty.TextInputLayout</item>
-        <item name="textInputEditTextStyle">@style/Widget.Texty.TextInputEditText</item>
     </style>
 
     <!-- Alias del tema de la app (igual que en values/) -->

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -71,7 +71,6 @@
         <item name="boxStrokeColor">@color/text_input_stroke</item>
         <item name="boxBackgroundColor">@color/md_theme_light_surfaceVariant</item>
         <item name="hintTextColor">@color/text_input_hint</item>
-        <item name="android:hintTextColor">@color/text_input_hint</item>
         <item name="startIconTint">@color/text_input_icon</item>
         <item name="endIconTint">@color/text_input_icon</item>
         <item name="shapeAppearance">@style/ShapeAppearance.Material3.Corner.Medium</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -31,7 +31,6 @@
 
         <item name="toolbarStyle">@style/AppToolbar</item>
         <item name="textInputStyle">@style/Widget.Texty.TextInputLayout</item>
-        <item name="textInputEditTextStyle">@style/Widget.Texty.TextInputEditText</item>
     </style>
 
     <!-- Tema de la app -->


### PR DESCRIPTION
## Summary
- remove theme reference to textInputEditTextStyle that prevented resource linking
- drop invalid android:hintTextColor override from the TextInputLayout style

## Testing
- `./gradlew :app:assembleDebug` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68d38b0d0e9c83209b800f4fb02d1323