### PR TITLE
Fix resource references for text input and send button

### DIFF
--- a/app/src/main/res/color/text_input_stroke.xml
+++ b/app/src/main/res/color/text_input_stroke.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_error="true" android:color="@color/colorError" />
     <item android:state_focused="true" android:color="@color/md_theme_light_primary" />
     <item android:color="@color/md_theme_light_outline" />
 </selector>

--- a/app/src/main/res/layout/activity_chat.xml
+++ b/app/src/main/res/layout/activity_chat.xml
@@ -147,7 +147,7 @@
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/buttonSend"
-                style="@style/Widget.Material3.Button.Filled"
+                style="@style/Widget.Material3.Button"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:minWidth="0dp"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -69,6 +69,7 @@
         <item name="boxStrokeWidth">1dp</item>
         <item name="boxStrokeWidthFocused">2dp</item>
         <item name="boxStrokeColor">@color/text_input_stroke</item>
+        <item name="boxStrokeErrorColor">@color/colorError</item>
         <item name="boxBackgroundColor">@color/md_theme_light_surfaceVariant</item>
         <item name="hintTextColor">@color/text_input_hint</item>
         <item name="startIconTint">@color/text_input_icon</item>


### PR DESCRIPTION
## Summary
- remove the unsupported state_error selector from the text input stroke color list
- configure the text input layout style with an explicit error stroke color
- swap the chat send button to use the available base Material3 button style

## Testing
- ./gradlew assembleDebug *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68d38c1276048320bbcd137a54a9e7f7