### PR TITLE
Fix chat list search layout dimensions

### DIFF
--- a/app/src/main/res/layout/fragment_chat_list.xml
+++ b/app/src/main/res/layout/fragment_chat_list.xml
@@ -20,6 +20,8 @@
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/searchLayout"
         style="@style/Widget.Texty.TextInputLayout"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
         android:layout_marginStart="20dp"
         android:layout_marginTop="16dp"
         android:layout_marginEnd="20dp"
@@ -31,6 +33,8 @@
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/editSearch"
             style="@style/Widget.Texty.TextInputEditText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             android:hint="@string/search_hint"
             android:imeOptions="actionSearch"
             android:inputType="text" />


### PR DESCRIPTION
## Summary
- add explicit width and height attributes to the chat search TextInputLayout so it can be inflated inside the ConstraintLayout
- ensure the nested TextInputEditText uses match_parent width to satisfy layout params

## Testing
- `./gradlew lintVitalRelease` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68d391437ac48320a16df45ae5e8d883