### PR TITLE
Fix chat item title missing layout width

### DIFF
--- a/app/src/main/res/layout/item_chat.xml
+++ b/app/src/main/res/layout/item_chat.xml
@@ -46,6 +46,8 @@
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/textName"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
                 style="@style/TextAppearance.Material3.TitleMedium"
                 android:textColor="?attr/colorOnSurface" />
 


### PR DESCRIPTION
## Summary
- set explicit width and height on the chat list title text to satisfy layout params

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68d392e46c808320912abbac6bd8907a