### PR TITLE
Fix profile fragment text fields layout params

### DIFF
--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -81,6 +81,7 @@
                         android:id="@+id/nameLayout"
                         style="@style/Widget.Texty.TextInputLayout"
                         android:layout_width="0dp"
+                        android:layout_height="wrap_content"
                         android:layout_marginTop="24dp"
                         app:layout_constraintTop_toBottomOf="@id/imageProfile"
                         app:layout_constraintStart_toStartOf="parent"
@@ -89,6 +90,8 @@
                         <com.google.android.material.textfield.TextInputEditText
                             android:id="@+id/editDisplayName"
                             style="@style/Widget.Texty.TextInputEditText"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
                             android:hint="@string/display_name" />
                     </com.google.android.material.textfield.TextInputLayout>
 
@@ -110,11 +113,14 @@
                 android:id="@+id/aboutLayout"
                 style="@style/Widget.Texty.TextInputLayout"
                 android:layout_width="match_parent"
+                android:layout_height="wrap_content"
                 android:layout_marginBottom="20dp">
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/editAbout"
                     style="@style/Widget.Texty.TextInputEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
                     android:gravity="top|start"
                     android:hint="@string/profile_about"
                     android:inputType="textMultiLine"
@@ -126,11 +132,14 @@
                 android:id="@+id/phoneLayout"
                 style="@style/Widget.Texty.TextInputLayout"
                 android:layout_width="match_parent"
+                android:layout_height="wrap_content"
                 android:layout_marginBottom="20dp">
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/editPhone"
                     style="@style/Widget.Texty.TextInputEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
                     android:hint="@string/profile_phone"
                     android:inputType="phone" />
 


### PR DESCRIPTION
## Summary
- add explicit width and height attributes to profile TextInputEditText fields to satisfy layout requirements
- set TextInputLayout heights to wrap content for consistent constraint handling

## Testing
- ./gradlew lint *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68d394075ce883209a03f53c893ef111