### PR TITLE
Fix chat TextInputEditText missing layout dimensions

### DIFF
--- a/app/src/main/res/layout/activity_chat.xml
+++ b/app/src/main/res/layout/activity_chat.xml
@@ -138,6 +138,8 @@
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/editMessage"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
                     style="@style/Widget.Texty.TextInputEditText"
                     android:hint="@string/chat_message_hint"
                     android:inputType="textCapSentences|textMultiLine"


### PR DESCRIPTION
## Summary
- add explicit width and height attributes to the chat screen TextInputEditText so it can inflate correctly

## Testing
- ./gradlew lint *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68d39508358883209ca9c1ce96a61504