### PR TITLE
Fix chat layout inflation crash

### DIFF
--- a/app/src/main/java/com/example/texty/ui/ChatActivity.kt
+++ b/app/src/main/java/com/example/texty/ui/ChatActivity.kt
@@ -134,6 +134,7 @@ class ChatActivity : AppCompatActivity() {
     setContentView(R.layout.activity_chat)
 
     val sendImageButton = findViewById<MaterialButton>(R.id.buttonSendImage)
+    sendImageButton.contentDescription = getString(R.string.chat_add_image)
     val toolbar = findViewById<MaterialToolbar>(R.id.topAppBar)
     setSupportActionBar(toolbar)
     supportActionBar?.setDisplayHomeAsUpEnabled(true)
@@ -147,6 +148,7 @@ class ChatActivity : AppCompatActivity() {
     recyclerView = findViewById(R.id.recyclerView)
     messageInput = findViewById(R.id.editMessage)
     sendButton = findViewById(R.id.buttonSend)
+    sendButton.setText(R.string.chat_action_send)
 
     //adapter = ChatAdapter(currentUid)
     adapter = ChatAdapter(currentUid) { msg, iv, tv ->

--- a/app/src/main/res/layout/activity_chat.xml
+++ b/app/src/main/res/layout/activity_chat.xml
@@ -120,7 +120,6 @@
                 style="@style/AppButton.Icon"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:contentDescription="@string/chat_add_image"
                 app:icon="@drawable/baseline_add_photo_alternate_24"
                 app:iconTint="?attr/colorOnSurfaceVariant" />
 
@@ -155,7 +154,6 @@
                 android:minWidth="0dp"
                 android:paddingHorizontal="18dp"
                 android:paddingVertical="10dp"
-                android:text="@string/chat_action_send"
                 android:textAllCaps="false"
                 android:textColor="?attr/colorOnPrimary"
                 app:backgroundTint="@color/md_theme_light_primary"


### PR DESCRIPTION
## Summary
- remove inline string attributes from the chat composer buttons to avoid the runtime inflation crash on legacy devices
- configure the send button label and image button content description programmatically after inflating the layout to preserve accessibility and localization

## Testing
- ⚠️ `./gradlew :app:assembleDebug` *(fails: unable to download Gradle distribution because outbound network access is blocked in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d395d0a7288320937caa61f9276731