### PR TITLE
Fix chat send button styling crash on API 24

### DIFF
--- a/app/src/main/res/layout/activity_chat.xml
+++ b/app/src/main/res/layout/activity_chat.xml
@@ -148,19 +148,10 @@
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/buttonSend"
-                style="@style/Widget.Material3.Button"
+                style="@style/Widget.Texty.SendButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:minWidth="0dp"
-                android:paddingHorizontal="18dp"
-                android:paddingVertical="10dp"
-                android:textAllCaps="false"
-                android:textColor="?attr/colorOnPrimary"
-                app:backgroundTint="@color/md_theme_light_primary"
-                app:icon="@drawable/ic_send"
-                app:iconGravity="textStart"
-                app:iconPadding="8dp"
-                app:iconTint="?attr/colorOnPrimary" />
+                app:icon="@drawable/ic_send" />
         </LinearLayout>
     </com.google.android.material.card.MaterialCardView>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -61,6 +61,18 @@
         <item name="shapeAppearance">?attr/shapeAppearanceLargeComponent</item>
     </style>
 
+    <style name="Widget.Texty.SendButton" parent="Widget.MaterialComponents.Button">
+        <item name="android:minWidth">0dp</item>
+        <item name="android:paddingHorizontal">18dp</item>
+        <item name="android:paddingVertical">10dp</item>
+        <item name="android:textAllCaps">false</item>
+        <item name="android:textColor">?attr/colorOnPrimary</item>
+        <item name="backgroundTint">@color/md_theme_light_primary</item>
+        <item name="iconPadding">8dp</item>
+        <item name="iconGravity">textStart</item>
+        <item name="iconTint">?attr/colorOnPrimary</item>
+    </style>
+
     <style name="Widget.Texty.TextInputLayout" parent="Widget.Material3.TextInputLayout.OutlinedBox">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>


### PR DESCRIPTION
## Summary
- replace the chat send button's Material3 widget style with a custom compatibility style to avoid API 24 inflation crashes
- move the button tint and text color configuration into the new `Widget.Texty.SendButton` style to preserve the intended visuals

## Testing
- ⚠️ `./gradlew lint` *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d822739a908320a5a1cdd1961a2fa9