### PR TITLE
Adjust profile card headers for full width

### DIFF
--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -165,6 +165,8 @@
 
                     <com.google.android.material.textview.MaterialTextView
                         style="@style/TextAppearance.Material3.TitleSmall"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
                         android:text="@string/notifications" />
 
                     <com.google.android.material.materialswitch.MaterialSwitch
@@ -197,6 +199,8 @@
 
                     <com.google.android.material.textview.MaterialTextView
                         style="@style/TextAppearance.Material3.TitleSmall"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
                         android:text="@string/privacy" />
 
                     <com.google.android.material.materialswitch.MaterialSwitch


### PR DESCRIPTION
## Summary
- set the notification and privacy section headers to match the full card width to avoid layout issues

## Testing
- ./gradlew assembleDebug *(fails: missing Android SDK in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d825fbee948320a3dbdd6f2fd8b80a