### PR TITLE
Preload user presence in chat list

### DIFF
--- a/app/src/main/java/com/example/texty/ui/ChatListFragment.kt
+++ b/app/src/main/java/com/example/texty/ui/ChatListFragment.kt
@@ -106,6 +106,7 @@ class ChatListFragment : Fragment() {
             val uid = Firebase.auth.currentUser?.uid ?: return@observe // 👈 evita crash tras logout
 
             UserRepository().getFriends(uid, onSuccess = { friends ->
+                adapter.updatePresence(friends.associate { it.uid to it.isOnline })
                 val friendRooms = friends.map { user ->
                     ChatRoom(
                         id = user.uid,
@@ -147,6 +148,7 @@ class ChatListFragment : Fragment() {
     private fun loadFriends(uid: String) {
         userRepository.getFriends(uid, onSuccess = { friends ->
             cachedFriends = friends
+            adapter.updatePresence(friends.associate { it.uid to it.isOnline })
             val currentRooms = pendingRooms ?: viewModel.rooms.value ?: emptyList()
             pendingRooms = null
             combineRoomsAndRender(currentRooms, friends)


### PR DESCRIPTION
## Summary
- add cached presence map to ChatListAdapter and use it to render status indicators without per-row Firestore reads
- update ChatListFragment to pass friend presence data into the adapter whenever friends load

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8286fd2d08320a0c06b9c964e1b50