### PR TITLE
Improve validation in group creation dialog

### DIFF
--- a/app/src/main/java/com/example/texty/ui/ChatListFragment.kt
+++ b/app/src/main/java/com/example/texty/ui/ChatListFragment.kt
@@ -21,7 +21,9 @@ import com.example.texty.util.AppLogger
 import com.example.texty.util.ErrorLogger
 import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.progressindicator.CircularProgressIndicator
+import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.textfield.TextInputEditText
+import com.google.android.material.textfield.TextInputLayout
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.ktx.Firebase
 
@@ -244,6 +246,7 @@ class ChatListFragment : Fragment() {
         val dialogView = LayoutInflater.from(context).inflate(R.layout.dialog_create_group, null)
         val recycler = dialogView.findViewById<RecyclerView>(R.id.recyclerFriends)
         val editGroupName = dialogView.findViewById<TextInputEditText>(R.id.editGroupName)
+        val groupNameLayout = dialogView.findViewById<TextInputLayout>(R.id.groupNameLayout)
         val searchInput = dialogView.findViewById<TextInputEditText>(R.id.editSearchFriends)
 
         recycler.layoutManager = LinearLayoutManager(context)
@@ -297,12 +300,36 @@ class ChatListFragment : Fragment() {
             val dialog = androidx.appcompat.app.AlertDialog.Builder(context)
                 .setTitle("Nuevo grupo")
                 .setView(dialogView)
-                .setPositiveButton("Crear") { d, _ ->
+                .setPositiveButton("Crear", null)
+                .setNegativeButton("Cancelar") { d, _ -> d.dismiss() }
+                .create()
+
+            dialog.setOnShowListener {
+                val createButton = dialog.getButton(androidx.appcompat.app.AlertDialog.BUTTON_POSITIVE)
+                createButton.isEnabled = !editGroupName.text.isNullOrBlank()
+
+                editGroupName.addTextChangedListener { text ->
+                    groupNameLayout.error = null
+                    createButton.isEnabled = !text.isNullOrBlank()
+                }
+
+                createButton.setOnClickListener {
                     val groupName = editGroupName.text?.toString()?.trim().orEmpty()
-                    if (groupName.isBlank() || selectedFriends.isEmpty()) {
-                        AppLogger.logError(context, Exception("Falta nombre o miembros"))
-                        return@setPositiveButton
+                    var isValid = true
+
+                    if (groupName.isBlank()) {
+                        groupNameLayout.error = getString(R.string.error_group_name_required)
+                        isValid = false
+                    } else {
+                        groupNameLayout.error = null
                     }
+
+                    if (selectedFriends.isEmpty()) {
+                        Snackbar.make(dialogView, R.string.error_group_members_required, Snackbar.LENGTH_SHORT).show()
+                        isValid = false
+                    }
+
+                    if (!isValid) return@setOnClickListener
 
                     // Construir ChatRoom
                     val selectedUsers = friends.filter { selectedFriends.contains(it.uid) }
@@ -323,10 +350,9 @@ class ChatListFragment : Fragment() {
                         },
                     )
 
-                    d.dismiss()
+                    dialog.dismiss()
                 }
-                .setNegativeButton("Cancelar") { d, _ -> d.dismiss() }
-                .create()
+            }
 
             dialog.show()
 

--- a/app/src/main/res/layout/dialog_create_group.xml
+++ b/app/src/main/res/layout/dialog_create_group.xml
@@ -8,6 +8,7 @@
 
     <!-- Nombre del grupo -->
     <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/groupNameLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="Nombre del grupo">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,6 +22,8 @@
     <string name="no_chats_placeholder">No tienes chats aún</string>
     <string name="share_logs">Compartir logs</string>
     <string name="new_chat">Nuevo chat</string>
+    <string name="error_group_name_required">Escribe un nombre para el grupo</string>
+    <string name="error_group_members_required">Selecciona al menos un miembro</string>
     <string name="login_title">Iniciar sesión</string>
     <string name="register_title">Registro</string>
     <string name="search_user_title">Buscar usuario</string>


### PR DESCRIPTION
## Summary
- keep the group creation dialog open until a valid name and selection are provided, surfacing errors via the text field and a snackbar
- disable the create action until the group name is filled and add error copy for guidance

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd4a2293fc8320b659c10d1db5d66e