### PR TITLE
Add logout confirmation dialog

### DIFF
--- a/app/src/main/java/com/example/texty/ui/ProfileFragment.kt
+++ b/app/src/main/java/com/example/texty/ui/ProfileFragment.kt
@@ -16,6 +16,7 @@ import com.bumptech.glide.Glide
 import com.example.texty.R
 import com.example.texty.model.User
 import com.google.android.material.button.MaterialButton
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textfield.TextInputEditText
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.ktx.userProfileChangeRequest
@@ -185,9 +186,16 @@ class ProfileFragment : Fragment() {
         }
 
         buttonLogout.setOnClickListener {
-            FirebaseAuth.getInstance().signOut()
-            startActivity(Intent(requireContext(), LoginActivity::class.java))
-            requireActivity().finish()
+            MaterialAlertDialogBuilder(requireContext())
+                .setTitle(R.string.logout_confirmation_title)
+                .setMessage(R.string.logout_confirmation_message)
+                .setNegativeButton(R.string.cancel, null)
+                .setPositiveButton(R.string.logout) { _, _ ->
+                    FirebaseAuth.getInstance().signOut()
+                    startActivity(Intent(requireContext(), LoginActivity::class.java))
+                    requireActivity().finish()
+                }
+                .show()
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,6 +39,9 @@
     <string name="enable_notifications">Recibir notificaciones</string>
     <string name="privacy">Privacidad</string>
     <string name="private_account">Cuenta privada</string>
+    <string name="logout_confirmation_title">¿Cerrar sesión?</string>
+    <string name="logout_confirmation_message">Tu sesión se mantendrá activa si cancelas.</string>
+    <string name="cancel">Cancelar</string>
     <string name="error_not_friends">Debes ser amigo para chatear</string>
     <string name="chat_message_unavailable">Nuevo Chat.</string>
     <string name="chat_message_unavailable_resync">Mensaje no disponible. Sincroniza tus claves.</string>

--- a/docs/manual-tests.md
+++ b/docs/manual-tests.md
@@ -1,0 +1,9 @@
+# Pruebas manuales
+
+## Confirmación de cierre de sesión
+1. Abrir la pantalla de perfil con una cuenta autenticada.
+2. Pulsar el botón **Cerrar sesión**.
+3. En el cuadro de diálogo, elegir **Cancelar**.
+4. Verificar que el cuadro de diálogo se cierra, la sesión permanece activa y la pantalla de perfil sigue visible.
+5. Repetir el flujo y esta vez pulsar **Cerrar sesión** en el cuadro de diálogo.
+6. Confirmar que la app navega a la pantalla de inicio de sesión y la sesión actual se cierra.


### PR DESCRIPTION
## Summary
- wrap logout action in a confirmation dialog with cancel and confirm options
- add localized strings and manual test steps covering the cancellation flow

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd4b284ca08320aeae6e78b77c3a3c