### PR TITLE
Handle unsaved profile edits before navigation

### DIFF
--- a/app/src/main/java/com/example/texty/ui/PendingChangesHandler.kt
+++ b/app/src/main/java/com/example/texty/ui/PendingChangesHandler.kt
@@ -1,0 +1,6 @@
+package com.example.texty.ui
+
+interface PendingChangesHandler {
+    fun hasPendingChanges(): Boolean
+    fun onAttemptExit(onContinue: () -> Unit)
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,6 +42,10 @@
     <string name="logout_confirmation_title">¿Cerrar sesión?</string>
     <string name="logout_confirmation_message">Tu sesión se mantendrá activa si cancelas.</string>
     <string name="cancel">Cancelar</string>
+    <string name="unsaved_changes_title">¿Descartar cambios?</string>
+    <string name="unsaved_changes_message">Tienes cambios sin guardar en tu perfil. Si sales ahora, se perderán.</string>
+    <string name="keep_editing">Seguir editando</string>
+    <string name="discard_changes">Salir sin guardar</string>
     <string name="error_not_friends">Debes ser amigo para chatear</string>
     <string name="chat_message_unavailable">Nuevo Chat.</string>
     <string name="chat_message_unavailable_resync">Mensaje no disponible. Sincroniza tus claves.</string>


### PR DESCRIPTION
## Summary
- add a PendingChangesHandler contract and implement it in ProfileFragment to detect unsaved edits and intercept back presses
- reuse the handler from MainActivity so bottom navigation only leaves the profile after confirmation when there are pending changes
- introduce shared strings for the unsaved changes confirmation dialog

## Testing
- ./gradlew :app:lint *(fails: SDK location not found in the CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd4c3977f08320a70751d1277b058b