### PR TITLE
Adjust image preview text to remove encrypted wording

### DIFF
--- a/app/src/main/java/com/example/texty/repository/MessageMapper.kt
+++ b/app/src/main/java/com/example/texty/repository/MessageMapper.kt
@@ -170,7 +170,7 @@ class MessageMapper(
         val normalizedType = messageType?.lowercase(Locale.US) ?: ""
         return when {
             normalizedType.startsWith("text") -> body.text.orEmpty()
-            normalizedType.contains("image") -> "\uD83D\uDCF7 Imagen"
+            normalizedType.contains("image") -> "Imagen"
             normalizedType.startsWith("media") -> "\uD83D\uDCCE Archivo cifrado"
             body.text != null -> body.text
             else -> "\uD83D\uDCCE Archivo cifrado"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,7 +54,7 @@
     <string name="chat_session_missing_keys">No se encontró la clave de sesión. Re-sincroniza antes de enviar.</string>
     <string name="chat_message_encrypt_error">No se pudo cifrar el mensaje.</string>
     <string name="chat_message_send_error">No se pudo enviar el mensaje.</string>
-    <string name="chat_message_image_preview">📷 Imagen</string>
+    <string name="chat_message_image_preview">Imagen</string>
     <string name="chat_banner_icon_content_description">Mensaje enviado</string>
     <string name="chat_banner_message_sent">Mensaje enviado</string>
     <string name="chat_banner_preview_with_time">%1$s · %2$s</string>


### PR DESCRIPTION
## Summary
- update the image message preview string so it displays "Imagen"
- ensure MessageMapper also produces the same plain text when summarising image messages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd517bc2d083208d1f5dd5c0895761