### PR TITLE
Add leave group option to chat rooms

### DIFF
--- a/app/src/main/java/com/example/texty/ui/ChatListAdapter.kt
+++ b/app/src/main/java/com/example/texty/ui/ChatListAdapter.kt
@@ -42,7 +42,7 @@ class ChatListAdapter(
 
         // Nombre (grupo o individual)
         holder.nameText.text = if (room.isGroup) {
-            room.groupName ?: "Grupo sin nombre"
+            room.groupName ?: context.getString(R.string.chat_group_default_name)
         } else {
             val currentUserUid = Firebase.auth.currentUser?.uid
             val otherUid = room.participantIds.firstOrNull { it != currentUserUid }

--- a/app/src/main/java/com/example/texty/ui/ChatListFragment.kt
+++ b/app/src/main/java/com/example/texty/ui/ChatListFragment.kt
@@ -61,7 +61,7 @@ class ChatListFragment : Fragment() {
                 val intent = Intent(requireContext(), ChatActivity::class.java).apply {
                     putExtra("roomId", room.id)
                     putExtra("isGroup", true)
-                    putExtra("groupName", room.groupName ?: "Grupo sin nombre")
+                    putExtra("groupName", room.groupName ?: getString(R.string.chat_group_default_name))
                 }
                 startActivity(intent)
             } else {

--- a/app/src/main/res/drawable/baseline_exit_to_app_24.xml
+++ b/app/src/main/res/drawable/baseline_exit_to_app_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="?attr/colorOnSurface"
+        android:pathData="M10.09,15.59L11.5,17l5,-5 -5,-5 -1.41,1.41L12.67,11H3v2h9.67l-2.58,2.59zM19,3h-6v2h6v14h-6v2h6c1.1,0 2,-0.9 2,-2V5c0,-1.1 -0.9,-2 -2,-2z" />
+</vector>

--- a/app/src/main/res/menu/menu_chat_group.xml
+++ b/app/src/main/res/menu/menu_chat_group.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/action_leave_group"
+        android:title="@string/chat_leave_group_action"
+        android:icon="@drawable/baseline_exit_to_app_24"
+        app:showAsAction="ifRoom" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,6 +61,13 @@
     <string name="chat_add_image">Adjuntar imagen</string>
     <string name="chat_message_hint">Escribe un mensaje</string>
     <string name="chat_action_send">Enviar</string>
+    <string name="chat_group_default_name">Grupo sin nombre</string>
+    <string name="chat_leave_group_action">Salir del grupo</string>
+    <string name="chat_leave_group_title">¿Salir del grupo?</string>
+    <string name="chat_leave_group_message">Ya no recibirás mensajes de %1$s. ¿Deseas salir?</string>
+    <string name="chat_leave_group_confirm">Salir</string>
+    <string name="chat_leave_group_success">Saliste del grupo.</string>
+    <string name="chat_leave_group_error">No se pudo salir del grupo. Inténtalo de nuevo.</string>
     <string name="notification_generic_title">Nuevo mensaje</string>
     <string name="notification_generic_body">Tienes un mensaje nuevo</string>
     <string name="permissions_title">Permisos necesarios</string>


### PR DESCRIPTION
## Summary
- add a leave group action and confirmation flow in ChatActivity
- implement ChatRoomRepository.leaveGroup to clean membership data and rotate keys
- ensure chat lists drop departed groups and localize new strings/icons

## Testing
- ./gradlew :app:lintDebug *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd56b783f48320b251f73cb1a56924