### PR TITLE
Enable group admins to add members with key rotation

### DIFF
--- a/app/src/main/res/drawable/baseline_person_add_24.xml
+++ b/app/src/main/res/drawable/baseline_person_add_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M15,12c2.21,0 4,-1.79 4,-4s-1.79,-4 -4,-4 -4,1.79 -4,4 1.79,4 4,4zM6,10L6,7L4,7v3H1v2h3v3h2v-3h3v-2H6zm9,2c-2.67,0 -8,1.34 -8,4v2h16v-2c0,-2.66 -5.33,-4 -8,-4z" />
+</vector>

--- a/app/src/main/res/menu/menu_chat_group.xml
+++ b/app/src/main/res/menu/menu_chat_group.xml
@@ -3,6 +3,13 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
+        android:id="@+id/action_add_members"
+        android:title="@string/chat_add_members_action"
+        android:icon="@drawable/baseline_person_add_24"
+        android:visible="false"
+        app:showAsAction="ifRoom" />
+
+    <item
         android:id="@+id/action_leave_group"
         android:title="@string/chat_leave_group_action"
         android:icon="@drawable/baseline_exit_to_app_24"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,6 +62,12 @@
     <string name="chat_message_hint">Escribe un mensaje</string>
     <string name="chat_action_send">Enviar</string>
     <string name="chat_group_default_name">Grupo sin nombre</string>
+    <string name="chat_add_members_action">Agregar miembros</string>
+    <string name="chat_add_members_title">Agregar integrantes</string>
+    <string name="chat_add_members_confirm">Agregar</string>
+    <string name="chat_add_members_success">Se agregaron los nuevos miembros.</string>
+    <string name="chat_add_members_error">No se pudieron agregar los miembros.</string>
+    <string name="chat_add_members_empty">Todos tus amigos ya están en el grupo.</string>
     <string name="chat_leave_group_action">Salir del grupo</string>
     <string name="chat_leave_group_title">¿Salir del grupo?</string>
     <string name="chat_leave_group_message">Ya no recibirás mensajes de %1$s. ¿Deseas salir?</string>


### PR DESCRIPTION
## Summary
- add ChatRoomRepository.addMembers to update group participants, provision encrypted keys for new members, and trigger a key rotation
- expose an add-members dialog for group admins in ChatActivity and update menus/resources accordingly
- add supporting resources including strings and an icon for the new action

## Testing
- ./gradlew test *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dd5afa47548320a41bed5b02375002