### PR TITLE
Fix userNames map materialization in addMembers

### DIFF
--- a/app/src/main/java/com/example/texty/repository/ChatRoomRepository.kt
+++ b/app/src/main/java/com/example/texty/repository/ChatRoomRepository.kt
@@ -256,10 +256,11 @@ class ChatRoomRepository(
 
             val updatedParticipants = (currentParticipants + distinctNewMembers.map { it.uid }).distinct()
 
-            val userNames = (snapshot.get("userNames") as? Map<*, *>)
+            val existingUserNames = (snapshot.get("userNames") as? Map<*, *>)
                 ?.mapNotNull { (k, v) -> if (k is String && v is String) k to v else null }
-                ?.toMutableMap()
-                ?: mutableMapOf()
+                ?.associate { it }
+
+            val userNames = existingUserNames?.toMutableMap() ?: mutableMapOf<String, String>()
 
             distinctNewMembers.forEach { member ->
                 userNames[member.uid] = member.displayName.ifBlank { member.uid }


### PR DESCRIPTION
## Summary
- ensure user names map is materialized before creating a mutable copy when adding members

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dd61701f3c832097e145c90b87a269