### PR TITLE
Improve chat composer spacing

### DIFF
--- a/app/src/main/res/layout/activity_chat.xml
+++ b/app/src/main/res/layout/activity_chat.xml
@@ -96,7 +96,7 @@
         android:id="@+id/composerCard"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginHorizontal="16dp"
+        android:layout_marginHorizontal="12dp"
         android:layout_marginBottom="16dp"
         android:animateLayoutChanges="true"
         app:cardBackgroundColor="?attr/colorSurface"
@@ -110,10 +110,10 @@
             android:layout_height="wrap_content"
             android:gravity="center_vertical"
             android:orientation="horizontal"
-            android:paddingStart="12dp"
-            android:paddingEnd="12dp"
-            android:paddingTop="8dp"
-            android:paddingBottom="8dp">
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
+            android:paddingTop="12dp"
+            android:paddingBottom="12dp">
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/buttonSendImage"
@@ -126,10 +126,11 @@
             <com.google.android.material.textfield.TextInputLayout
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginEnd="8dp"
+                android:layout_marginStart="12dp"
+                android:layout_marginEnd="12dp"
                 android:layout_marginTop="0dp"
                 android:layout_weight="1"
+                android:minHeight="56dp"
                 style="@style/Widget.Texty.TextInputLayout"
                 app:endIconMode="none"
                 app:startIconDrawable="@drawable/baseline_add_reaction_24"
@@ -142,8 +143,11 @@
                     style="@style/Widget.Texty.TextInputEditText"
                     android:hint="@string/chat_message_hint"
                     android:inputType="textCapSentences|textMultiLine"
+                    android:gravity="top|start"
                     android:maxLines="4"
-                    android:minLines="1" />
+                    android:minHeight="56dp"
+                    android:minLines="1"
+                    android:paddingVertical="12dp" />
             </com.google.android.material.textfield.TextInputLayout>
 
             <com.google.android.material.button.MaterialButton


### PR DESCRIPTION
## Summary
- widen the chat composer card so the text field has more horizontal room
- increase padding and minimum heights to give the message input a taller, more comfortable appearance

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e407a76cb883208087249662555fe3