### PR TITLE
Replace auth error toasts with snackbars

### DIFF
--- a/app/src/main/java/com/example/texty/ui/LoginActivity.kt
+++ b/app/src/main/java/com/example/texty/ui/LoginActivity.kt
@@ -4,7 +4,6 @@ import android.content.Intent
 import android.os.Bundle
 import android.util.Patterns
 import android.view.View
-import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.example.texty.R
 import com.example.texty.util.AppLogger
@@ -18,6 +17,7 @@ import com.google.firebase.auth.FirebaseAuthInvalidUserException
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
 import com.google.android.material.progressindicator.CircularProgressIndicator
+import com.google.android.material.snackbar.Snackbar
 
 class LoginActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -81,7 +81,11 @@ class LoginActivity : AppCompatActivity() {
             is FirebaseNetworkException -> getString(R.string.error_network)
             else -> getString(R.string.error_generic)
           }
-          Toast.makeText(this, message, Toast.LENGTH_LONG).show()
+          Snackbar.make(
+            findViewById(android.R.id.content),
+            message,
+            Snackbar.LENGTH_LONG
+          ).show()
         }
     }
 

--- a/app/src/main/java/com/example/texty/ui/RegisterActivity.kt
+++ b/app/src/main/java/com/example/texty/ui/RegisterActivity.kt
@@ -3,7 +3,6 @@ package com.example.texty.ui
 import android.content.Intent
 import android.os.Bundle
 import android.util.Patterns
-import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import com.example.texty.R
@@ -23,6 +22,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withContext
+import com.google.android.material.snackbar.Snackbar
 
 class RegisterActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -98,10 +98,10 @@ class RegisterActivity : AppCompatActivity() {
           finish()
         } catch (e: Exception) {
           AppLogger.logError(this@RegisterActivity, e)
-          Toast.makeText(
-            this@RegisterActivity,
+          Snackbar.make(
+            findViewById(android.R.id.content),
             e.localizedMessage ?: getString(R.string.error_generic),
-            Toast.LENGTH_LONG
+            Snackbar.LENGTH_LONG
           ).show()
         } finally {
           registerButton.isEnabled = true


### PR DESCRIPTION
## Summary
- replace Toast-based error feedback in LoginActivity with a Snackbar tied to the activity root view
- update RegisterActivity to use the same Snackbar-based error feedback so both flows avoid the TextView inflation crash

## Testing
- `./gradlew lint` *(fails: Android SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e46cc993f88320bf1bbe6330ffe5a2