### PR TITLE
Fix realtime presence tracking via lifecycle observer

### DIFF
--- a/app/src/main/java/com/example/texty/TextyApplication.kt
+++ b/app/src/main/java/com/example/texty/TextyApplication.kt
@@ -2,6 +2,7 @@ package com.example.texty
 
 import android.app.Application
 import com.example.texty.util.AppLogger
+import com.example.texty.util.OnlineStatusTracker
 import com.google.android.material.color.DynamicColors
 import android.os.Build
 
@@ -14,6 +15,8 @@ class TextyApplication : Application() {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
       DynamicColors.applyToActivitiesIfAvailable(this)
     }
+
+    OnlineStatusTracker.initialize()
 
     val defaultHandler = Thread.getDefaultUncaughtExceptionHandler()
     // Registra logger para errores no controlados.

--- a/app/src/main/java/com/example/texty/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/texty/ui/MainActivity.kt
@@ -128,7 +128,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onStart() {
         super.onStart()
-        setOnlineStatus(true)
 
         // Solo pedimos notificaciones al iniciar (Android 13+).
         requestNotificationsWithRationale()
@@ -140,16 +139,6 @@ class MainActivity : AppCompatActivity() {
                 KeyRepository.getInstance(applicationContext).refreshOneTimePreKeysIfNeeded(uid)
             }
         }
-    }
-
-    override fun onStop() {
-        setOnlineStatus(false)
-        super.onStop()
-    }
-
-    private fun setOnlineStatus(online: Boolean) {
-        val uid = FirebaseAuth.getInstance().currentUser?.uid ?: return
-        Firebase.firestore.collection("users").document(uid).update("isOnline", online)
     }
 
     // -------------------- Notificaciones: token FCM --------------------

--- a/app/src/main/java/com/example/texty/util/OnlineStatusTracker.kt
+++ b/app/src/main/java/com/example/texty/util/OnlineStatusTracker.kt
@@ -1,0 +1,85 @@
+package com.example.texty.util
+
+import android.util.Log
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
+
+/**
+ * Tracks the online presence of the authenticated user and keeps Firestore updated in real time.
+ *
+ * This observer listens to both process level lifecycle events and FirebaseAuth state changes so
+ * that the `isOnline` flag reflects whether the app is in foreground with a logged in user.
+ */
+object OnlineStatusTracker : DefaultLifecycleObserver, FirebaseAuth.AuthStateListener {
+
+    private const val TAG = "OnlineStatusTracker"
+
+    private var initialized = false
+    private var currentUid: String? = null
+    private var lastReportedStatus: Boolean? = null
+    private var isInForeground = false
+
+    /** Call once from [android.app.Application.onCreate] to start monitoring. */
+    fun initialize() {
+        if (initialized) return
+        initialized = true
+
+        ProcessLifecycleOwner.get().lifecycle.addObserver(this)
+        FirebaseAuth.getInstance().addAuthStateListener(this)
+
+        isInForeground = ProcessLifecycleOwner.get().lifecycle.currentState.isAtLeast(
+            androidx.lifecycle.Lifecycle.State.STARTED
+        )
+        currentUid = FirebaseAuth.getInstance().currentUser?.uid
+        syncPresence()
+    }
+
+    override fun onStart(owner: LifecycleOwner) {
+        isInForeground = true
+        syncPresence()
+    }
+
+    override fun onStop(owner: LifecycleOwner) {
+        isInForeground = false
+        syncPresence()
+    }
+
+    override fun onAuthStateChanged(auth: FirebaseAuth) {
+        val newUid = auth.currentUser?.uid
+        val previousUid = currentUid
+
+        if (previousUid != null && previousUid != newUid) {
+            setOnlineStatus(previousUid, false)
+        }
+
+        currentUid = newUid
+        lastReportedStatus = null
+        syncPresence()
+    }
+
+    private fun syncPresence() {
+        val uid = currentUid ?: run {
+            lastReportedStatus = null
+            return
+        }
+
+        val desiredStatus = isInForeground
+        if (lastReportedStatus == desiredStatus) return
+
+        setOnlineStatus(uid, desiredStatus)
+        lastReportedStatus = desiredStatus
+    }
+
+    private fun setOnlineStatus(uid: String, online: Boolean) {
+        Firebase.firestore.collection("users")
+            .document(uid)
+            .update("isOnline", online)
+            .addOnFailureListener { e ->
+                Log.w(TAG, "No se pudo actualizar el estado en línea para $uid", e)
+            }
+    }
+}


### PR DESCRIPTION
## Summary
- add an OnlineStatusTracker that keeps Firestore presence in sync with the app lifecycle
- initialize the tracker from the application class and remove manual toggling from MainActivity

## Testing
- `./gradlew test` *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e477112e9883208d274c0b1278e03d