### PR TITLE
Refresh palette with softer gradients

### DIFF
--- a/app/src/main/res/drawable/bg_gradient_accent.xml
+++ b/app/src/main/res/drawable/bg_gradient_accent.xml
@@ -3,6 +3,6 @@
        android:shape="rectangle">
     <gradient
             android:angle="45"
-            android:startColor="#FF6B6B"
-            android:endColor="#F59E0B" />
+            android:startColor="#FBCFE8"
+            android:endColor="#C4B5FD" />
 </shape>

--- a/app/src/main/res/drawable/bg_gradient_primary.xml
+++ b/app/src/main/res/drawable/bg_gradient_primary.xml
@@ -3,6 +3,6 @@
        android:shape="rectangle">
     <gradient
             android:angle="45"
-            android:startColor="#6366F1"
-            android:endColor="#22D3EE" />
+            android:startColor="#9B8CFF"
+            android:endColor="#8BD5F3" />
 </shape>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="md_theme_light_primary">#6366F1</color>
-    <color name="md_theme_light_onPrimary">#FFFFFF</color>
-    <color name="md_theme_light_primaryContainer">#312E81</color>
-    <color name="md_theme_light_onPrimaryContainer">#E0E7FF</color>
+    <color name="md_theme_light_primary">#CFC5FF</color>
+    <color name="md_theme_light_onPrimary">#2D1B69</color>
+    <color name="md_theme_light_primaryContainer">#45358C</color>
+    <color name="md_theme_light_onPrimaryContainer">#EDE9FF</color>
 
-    <color name="md_theme_light_secondary">#22D3EE</color>
-    <color name="md_theme_light_onSecondary">#042F2E</color>
-    <color name="md_theme_light_secondaryContainer">#164E63</color>
-    <color name="md_theme_light_onSecondaryContainer">#ECFEFF</color>
+    <color name="md_theme_light_secondary">#F8AFD6</color>
+    <color name="md_theme_light_onSecondary">#3F1234</color>
+    <color name="md_theme_light_secondaryContainer">#5A2D52</color>
+    <color name="md_theme_light_onSecondaryContainer">#FCE7F3</color>
 
-    <color name="md_theme_light_tertiary">#FF6B6B</color>
-    <color name="md_theme_light_surface">#111827</color>
-    <color name="md_theme_light_surfaceVariant">#1E293B</color>
-    <color name="md_theme_light_surfaceContainer">#0B1120</color>
-    <color name="md_theme_light_onSurface">#F1F5F9</color>
-    <color name="md_theme_light_onSurfaceVariant">#9CA3AF</color>
-    <color name="md_theme_light_outline">#334155</color>
-    <color name="md_theme_light_outlineVariant">#1F2937</color>
-    <color name="md_theme_light_error">#EF4444</color>
-    <color name="md_theme_light_warning">#F59E0B</color>
-    <color name="md_theme_light_success">#22C55E</color>
+    <color name="md_theme_light_tertiary">#7AD3F2</color>
+    <color name="md_theme_light_surface">#131826</color>
+    <color name="md_theme_light_surfaceVariant">#1D2333</color>
+    <color name="md_theme_light_surfaceContainer">#101626</color>
+    <color name="md_theme_light_onSurface">#E2E8F0</color>
+    <color name="md_theme_light_onSurfaceVariant">#A1AECF</color>
+    <color name="md_theme_light_outline">#3B465D</color>
+    <color name="md_theme_light_outlineVariant">#262F45</color>
+    <color name="md_theme_light_error">#F87171</color>
+    <color name="md_theme_light_warning">#FBBF24</color>
+    <color name="md_theme_light_success">#34D399</color>
 
-    <color name="colorSuccess">#22C55E</color>
-    <color name="colorWarning">#F59E0B</color>
-    <color name="colorError">#EF4444</color>
+    <color name="colorSuccess">#34D399</color>
+    <color name="colorWarning">#FBBF24</color>
+    <color name="colorError">#F87171</color>
     <color name="colorInfo">#60A5FA</color>
 
-    <color name="colorCardStroke">#1F2937</color>
+    <color name="colorCardStroke">#262F45</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="md_theme_light_primary">#6366F1</color>
+    <color name="md_theme_light_primary">#9B8CFF</color>
     <color name="md_theme_light_onPrimary">#FFFFFF</color>
-    <color name="md_theme_light_primaryContainer">#E0E7FF</color>
-    <color name="md_theme_light_onPrimaryContainer">#1E1B4B</color>
+    <color name="md_theme_light_primaryContainer">#EDE9FF</color>
+    <color name="md_theme_light_onPrimaryContainer">#2D1B69</color>
 
-    <color name="md_theme_light_secondary">#22D3EE</color>
-    <color name="md_theme_light_onSecondary">#042F2E</color>
-    <color name="md_theme_light_secondaryContainer">#CFFAFE</color>
-    <color name="md_theme_light_onSecondaryContainer">#083344</color>
+    <color name="md_theme_light_secondary">#F8AFD6</color>
+    <color name="md_theme_light_onSecondary">#45103A</color>
+    <color name="md_theme_light_secondaryContainer">#FCE7F3</color>
+    <color name="md_theme_light_onSecondaryContainer">#6B1A4A</color>
 
-    <color name="md_theme_light_tertiary">#FF6B6B</color>
-    <color name="md_theme_light_surface">#FFFFFF</color>
-    <color name="md_theme_light_surfaceVariant">#F2F4F8</color>
-    <color name="md_theme_light_surfaceContainer">#F8FAFF</color>
-    <color name="md_theme_light_onSurface">#0F172A</color>
-    <color name="md_theme_light_onSurfaceVariant">#6B7280</color>
-    <color name="md_theme_light_outline">#D0D5DD</color>
+    <color name="md_theme_light_tertiary">#8BD5F3</color>
+    <color name="md_theme_light_surface">#FAFAFF</color>
+    <color name="md_theme_light_surfaceVariant">#F2F4FB</color>
+    <color name="md_theme_light_surfaceContainer">#F6F7FF</color>
+    <color name="md_theme_light_onSurface">#1F2937</color>
+    <color name="md_theme_light_onSurfaceVariant">#64748B</color>
+    <color name="md_theme_light_outline">#CBD5E1</color>
     <color name="md_theme_light_outlineVariant">#E2E8F0</color>
     <color name="md_theme_light_error">#EF4444</color>
     <color name="md_theme_light_warning">#F59E0B</color>
@@ -25,9 +25,9 @@
     <color name="colorSuccess">#22C55E</color>
     <color name="colorWarning">#F59E0B</color>
     <color name="colorError">#EF4444</color>
-    <color name="colorInfo">#3B82F6</color>
+    <color name="colorInfo">#38BDF8</color>
 
-    <color name="colorCardStroke">#E3E8F2</color>
+    <color name="colorCardStroke">#E5E7F5</color>
 
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>


### PR DESCRIPTION
## Summary
- replace the previous high-contrast purple and gold palette with a softer lavender, blush, and sky gradient theme
- tune both light and dark mode surface, outline, and feedback colors to keep the UI gentle on the eyes

## Testing
- Failed: ./gradlew :app:lintDebug (Android SDK not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e47fc680b88320b04281068b6a1593