### PR TITLE
Restyle chat interface with calming palette

### DIFF
--- a/app/src/main/res/color/switch_track_tint.xml
+++ b/app/src/main/res/color/switch_track_tint.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_checked="true" android:color="#66FBBF24" />
+    <item android:state_checked="true" android:color="#66C7AFFF" />
     <item android:color="#33FFFFFF" />
 </selector>

--- a/app/src/main/res/drawable/bg_app_gradient.xml
+++ b/app/src/main/res/drawable/bg_app_gradient.xml
@@ -2,8 +2,8 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <gradient
-        android:startColor="#0D0D0D"
-        android:endColor="#1C1C1C"
+        android:startColor="#19162A"
+        android:endColor="#121024"
         android:type="linear"
         android:angle="90" />
 </shape>

--- a/app/src/main/res/drawable/bg_avatar_halo.xml
+++ b/app/src/main/res/drawable/bg_avatar_halo.xml
@@ -6,8 +6,8 @@
         android:gradientRadius="24dp"
         android:centerX="50%"
         android:centerY="50%"
-        android:startColor="#66FBBF24"
-        android:endColor="#00FBBF24" />
+        android:startColor="#66C7AFFF"
+        android:endColor="#00C7AFFF" />
     <stroke
         android:width="1dp"
         android:color="@color/glass_stroke" />

--- a/app/src/main/res/drawable/bg_bottom_nav.xml
+++ b/app/src/main/res/drawable/bg_bottom_nav.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <solid android:color="#CC080808" />
+    <solid android:color="#CC1F1C32" />
     <corners android:topLeftRadius="28dp"
         android:topRightRadius="28dp" />
     <stroke

--- a/app/src/main/res/drawable/bg_gradient_accent.xml
+++ b/app/src/main/res/drawable/bg_gradient_accent.xml
@@ -3,6 +3,6 @@
        android:shape="rectangle">
     <gradient
             android:angle="45"
-            android:startColor="#FF6B6B"
-            android:endColor="#F59E0B" />
+            android:startColor="#F6BCD5"
+            android:endColor="#F7C27D" />
 </shape>

--- a/app/src/main/res/drawable/bg_gradient_primary.xml
+++ b/app/src/main/res/drawable/bg_gradient_primary.xml
@@ -3,6 +3,6 @@
        android:shape="rectangle">
     <gradient
             android:angle="45"
-            android:startColor="#6366F1"
-            android:endColor="#22D3EE" />
+            android:startColor="#BFA8FF"
+            android:endColor="#89D8C2" />
 </shape>

--- a/app/src/main/res/drawable/bg_toolbar_glass.xml
+++ b/app/src/main/res/drawable/bg_toolbar_glass.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <solid android:color="#BF161616" />
+    <solid android:color="#CC1D1A2F" />
     <corners android:bottomLeftRadius="28dp"
         android:bottomRightRadius="28dp" />
     <stroke

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="md_theme_light_primary">#6366F1</color>
-    <color name="md_theme_light_onPrimary">#FFFFFF</color>
-    <color name="md_theme_light_primaryContainer">#312E81</color>
-    <color name="md_theme_light_onPrimaryContainer">#E0E7FF</color>
+    <color name="md_theme_light_primary">#C7AFFF</color>
+    <color name="md_theme_light_onPrimary">#251A3C</color>
+    <color name="md_theme_light_primaryContainer">#3B2C55</color>
+    <color name="md_theme_light_onPrimaryContainer">#F4EDFF</color>
 
-    <color name="md_theme_light_secondary">#22D3EE</color>
-    <color name="md_theme_light_onSecondary">#042F2E</color>
-    <color name="md_theme_light_secondaryContainer">#164E63</color>
-    <color name="md_theme_light_onSecondaryContainer">#ECFEFF</color>
+    <color name="md_theme_light_secondary">#89D8C2</color>
+    <color name="md_theme_light_onSecondary">#08241E</color>
+    <color name="md_theme_light_secondaryContainer">#274F45</color>
+    <color name="md_theme_light_onSecondaryContainer">#DAF7EF</color>
 
-    <color name="md_theme_light_tertiary">#FF6B6B</color>
-    <color name="md_theme_light_surface">#111827</color>
-    <color name="md_theme_light_surfaceVariant">#1E293B</color>
-    <color name="md_theme_light_surfaceContainer">#0B1120</color>
-    <color name="md_theme_light_onSurface">#F1F5F9</color>
-    <color name="md_theme_light_onSurfaceVariant">#9CA3AF</color>
-    <color name="md_theme_light_outline">#334155</color>
-    <color name="md_theme_light_outlineVariant">#1F2937</color>
-    <color name="md_theme_light_error">#EF4444</color>
-    <color name="md_theme_light_warning">#F59E0B</color>
-    <color name="md_theme_light_success">#22C55E</color>
+    <color name="md_theme_light_tertiary">#F6BCD5</color>
+    <color name="md_theme_light_surface">#141223</color>
+    <color name="md_theme_light_surfaceVariant">#1C1A2C</color>
+    <color name="md_theme_light_surfaceContainer">#201E31</color>
+    <color name="md_theme_light_onSurface">#F6F2FF</color>
+    <color name="md_theme_light_onSurfaceVariant">#CBC6E1</color>
+    <color name="md_theme_light_outline">#3F3A53</color>
+    <color name="md_theme_light_outlineVariant">#2C283D</color>
+    <color name="md_theme_light_error">#F28B82</color>
+    <color name="md_theme_light_warning">#F7C27D</color>
+    <color name="md_theme_light_success">#8EE5C2</color>
 
-    <color name="colorSuccess">#22C55E</color>
-    <color name="colorWarning">#F59E0B</color>
-    <color name="colorError">#EF4444</color>
-    <color name="colorInfo">#60A5FA</color>
+    <color name="colorSuccess">#8EE5C2</color>
+    <color name="colorWarning">#F7C27D</color>
+    <color name="colorError">#F28B82</color>
+    <color name="colorInfo">#8ABFF9</color>
 
-    <color name="colorCardStroke">#1F2937</color>
+    <color name="colorCardStroke">#2C283D</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,49 +1,49 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Luxury amber & graphite palette -->
-    <color name="md_theme_light_primary">#FBBF24</color>
-    <color name="md_theme_light_onPrimary">#0F0F0F</color>
-    <color name="md_theme_light_primaryContainer">#FFE3A3</color>
-    <color name="md_theme_light_onPrimaryContainer">#070400</color>
+    <!-- Dreamy lavender & seafoam palette -->
+    <color name="md_theme_light_primary">#C7AFFF</color>
+    <color name="md_theme_light_onPrimary">#251A3C</color>
+    <color name="md_theme_light_primaryContainer">#3B2C55</color>
+    <color name="md_theme_light_onPrimaryContainer">#F4EDFF</color>
 
-    <color name="md_theme_light_secondary">#A0A0A0</color>
-    <color name="md_theme_light_onSecondary">#0F0F0F</color>
-    <color name="md_theme_light_secondaryContainer">#1F1F1F</color>
-    <color name="md_theme_light_onSecondaryContainer">#F5F5F5</color>
+    <color name="md_theme_light_secondary">#89D8C2</color>
+    <color name="md_theme_light_onSecondary">#08241E</color>
+    <color name="md_theme_light_secondaryContainer">#274F45</color>
+    <color name="md_theme_light_onSecondaryContainer">#DAF7EF</color>
 
-    <color name="md_theme_light_tertiary">#FFD580</color>
-    <color name="md_theme_light_surface">#0F0F0F</color>
-    <color name="md_theme_light_surfaceVariant">#141414</color>
-    <color name="md_theme_light_surfaceContainer">#161616</color>
-    <color name="md_theme_light_onSurface">#F5F5F5</color>
-    <color name="md_theme_light_onSurfaceVariant">#C0C0C0</color>
-    <color name="md_theme_light_outline">#333333</color>
-    <color name="md_theme_light_outlineVariant">#262626</color>
-    <color name="md_theme_light_error">#FF6B6B</color>
-    <color name="md_theme_light_warning">#E6A93E</color>
-    <color name="md_theme_light_success">#3DD598</color>
+    <color name="md_theme_light_tertiary">#F6BCD5</color>
+    <color name="md_theme_light_surface">#141223</color>
+    <color name="md_theme_light_surfaceVariant">#1C1A2C</color>
+    <color name="md_theme_light_surfaceContainer">#201E31</color>
+    <color name="md_theme_light_onSurface">#F6F2FF</color>
+    <color name="md_theme_light_onSurfaceVariant">#CBC6E1</color>
+    <color name="md_theme_light_outline">#3F3A53</color>
+    <color name="md_theme_light_outlineVariant">#2C283D</color>
+    <color name="md_theme_light_error">#F28B82</color>
+    <color name="md_theme_light_warning">#F7C27D</color>
+    <color name="md_theme_light_success">#8EE5C2</color>
 
-    <color name="colorSuccess">#3DD598</color>
-    <color name="colorWarning">#E6A93E</color>
-    <color name="colorError">#FF6B6B</color>
-    <color name="colorInfo">#58B7FF</color>
+    <color name="colorSuccess">#8EE5C2</color>
+    <color name="colorWarning">#F7C27D</color>
+    <color name="colorError">#F28B82</color>
+    <color name="colorInfo">#8ABFF9</color>
 
-    <color name="colorCardStroke">#33FFC45C</color>
-    <color name="glass_background">#26F5F5F5</color>
-    <color name="glass_background_elevated">#40F5F5F5</color>
-    <color name="glass_stroke">#40FBBF24</color>
+    <color name="colorCardStroke">#33C7AFFF</color>
+    <color name="glass_background">#1AE3E1F6</color>
+    <color name="glass_background_elevated">#26E3E1F6</color>
+    <color name="glass_stroke">#40C7AFFF</color>
 
-    <color name="message_incoming_bg">#CC1E1E1E</color>
-    <color name="message_incoming_stroke">#26FFFFFF</color>
-    <color name="message_outgoing_start">#FFD580</color>
-    <color name="message_outgoing_end">#E6A93E</color>
+    <color name="message_incoming_bg">#2B2539</color>
+    <color name="message_incoming_stroke">#4A4362</color>
+    <color name="message_outgoing_start">#BFA8FF</color>
+    <color name="message_outgoing_end">#9F8BEB</color>
 
-    <color name="text_primary">#F5F5F5</color>
-    <color name="text_secondary">#B8B8B8</color>
-    <color name="text_muted">#8A8A8A</color>
+    <color name="text_primary">#F6F2FF</color>
+    <color name="text_secondary">#CBC6E1</color>
+    <color name="text_muted">#A19DBD</color>
 
-    <color name="bottom_nav_active">#FBBF24</color>
-    <color name="bottom_nav_inactive">#A0A0A0</color>
+    <color name="bottom_nav_active">#C7AFFF</color>
+    <color name="bottom_nav_inactive">#7E799B</color>
 
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">ClassyChat</string>
+    <string name="app_name">LunaChat</string>
     <string name="invalid_email">Email inválido</string>
     <string name="invalid_password">La contraseña debe tener al menos 6 caracteres</string>
     <string name="error_generic">Error</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -3,19 +3,19 @@
 
     <style name="AppToolbar" parent="Widget.Material3.Toolbar">
         <item name="android:background">@drawable/bg_toolbar_glass</item>
-        <item name="titleTextColor">@color/md_theme_light_primary</item>
+        <item name="titleTextColor">@color/text_primary</item>
         <item name="subtitleTextColor">@color/text_secondary</item>
         <item name="android:popupTheme">@style/ThemeOverlay.Material3.Dark</item>
         <item name="android:elevation">0dp</item>
-        <item name="navigationIconTint">@color/md_theme_light_primary</item>
+        <item name="navigationIconTint">@color/text_primary</item>
         <item name="titleCentered">true</item>
     </style>
 
     <style name="AppToolbar.Surface" parent="AppToolbar">
         <item name="android:background">@drawable/bg_toolbar_glass</item>
-        <item name="titleTextColor">@color/md_theme_light_primary</item>
+        <item name="titleTextColor">@color/text_primary</item>
         <item name="subtitleTextColor">@color/text_secondary</item>
-        <item name="navigationIconTint">@color/md_theme_light_primary</item>
+        <item name="navigationIconTint">@color/text_primary</item>
     </style>
 
     <style name="AppButton" parent="Widget.Material3.Button">


### PR DESCRIPTION
## Summary
- rename the app branding to LunaChat and update toolbar styling for friendlier typography
- refresh the global color palette and gradients with a soft lavender and seafoam theme for a calmer chat experience
- retint shared drawables such as the bottom navigation, avatar halos, and switch tracks to align with the new aesthetic

## Testing
- ./gradlew lint *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4819c83dc83209c7a71219eb088e8