### PR TITLE
Adopt luxe noir palette across app UI

### DIFF
--- a/app/src/main/java/com/example/texty/ui/ChatListFragment.kt
+++ b/app/src/main/java/com/example/texty/ui/ChatListFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.*
 import android.widget.CheckBox
 import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
 import androidx.core.widget.addTextChangedListener
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -58,7 +59,8 @@ class ChatListFragment : Fragment() {
 
         val currentUser = Firebase.auth.currentUser ?: return // 👈 evita crash si ya está null
         val toolbar = view.findViewById<MaterialToolbar>(R.id.topAppBar)
-        (requireActivity() as androidx.appcompat.app.AppCompatActivity).setSupportActionBar(toolbar)
+        val activity = requireActivity() as AppCompatActivity
+        activity.setSupportActionBar(toolbar)
 
         adapter = ChatListAdapter { room ->
             if (room.isGroup) {

--- a/app/src/main/java/com/example/texty/ui/FriendRequestsFragment.kt
+++ b/app/src/main/java/com/example/texty/ui/FriendRequestsFragment.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -35,7 +36,8 @@ class FriendRequestsFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val toolbar = view.findViewById<MaterialToolbar>(R.id.topAppBar)
-        (requireActivity() as androidx.appcompat.app.AppCompatActivity).setSupportActionBar(toolbar)
+        val activity = requireActivity() as AppCompatActivity
+        activity.setSupportActionBar(toolbar)
 
         adapter = FriendRequestAdapter(
             onAccept = { request -> accept(request) },

--- a/app/src/main/java/com/example/texty/ui/SearchUserFragment.kt
+++ b/app/src/main/java/com/example/texty/ui/SearchUserFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -46,7 +47,8 @@ class SearchUserFragment : Fragment() {
         currentUid = auth.currentUser!!.uid
 
         val toolbar = view.findViewById<MaterialToolbar>(R.id.topAppBar)
-        (requireActivity() as androidx.appcompat.app.AppCompatActivity).setSupportActionBar(toolbar)
+        val activity = requireActivity() as AppCompatActivity
+        activity.setSupportActionBar(toolbar)
 
         adapter = UserAdapter(
             onClick = { user ->

--- a/app/src/main/res/drawable/bg_app_gradient.xml
+++ b/app/src/main/res/drawable/bg_app_gradient.xml
@@ -2,8 +2,8 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <gradient
-        android:startColor="#19162A"
-        android:endColor="#121024"
+        android:startColor="#05030B"
+        android:endColor="#170A32"
         android:type="linear"
         android:angle="90" />
 </shape>

--- a/app/src/main/res/drawable/bg_avatar_halo.xml
+++ b/app/src/main/res/drawable/bg_avatar_halo.xml
@@ -6,8 +6,8 @@
         android:gradientRadius="24dp"
         android:centerX="50%"
         android:centerY="50%"
-        android:startColor="#66C7AFFF"
-        android:endColor="#00C7AFFF" />
+        android:startColor="#66A678FF"
+        android:endColor="#00A678FF" />
     <stroke
         android:width="1dp"
         android:color="@color/glass_stroke" />

--- a/app/src/main/res/drawable/bg_bottom_nav.xml
+++ b/app/src/main/res/drawable/bg_bottom_nav.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <solid android:color="#CC1F1C32" />
+    <solid android:color="#CC0E071D" />
     <corners android:topLeftRadius="28dp"
         android:topRightRadius="28dp" />
     <stroke

--- a/app/src/main/res/drawable/bg_gradient_accent.xml
+++ b/app/src/main/res/drawable/bg_gradient_accent.xml
@@ -3,6 +3,6 @@
        android:shape="rectangle">
     <gradient
             android:angle="45"
-            android:startColor="#F6BCD5"
-            android:endColor="#F7C27D" />
+            android:startColor="#E6C6FF"
+            android:endColor="#8F5CFF" />
 </shape>

--- a/app/src/main/res/drawable/bg_gradient_primary.xml
+++ b/app/src/main/res/drawable/bg_gradient_primary.xml
@@ -3,6 +3,6 @@
        android:shape="rectangle">
     <gradient
             android:angle="45"
-            android:startColor="#BFA8FF"
-            android:endColor="#89D8C2" />
+            android:startColor="#CDB0FF"
+            android:endColor="#6F3BFF" />
 </shape>

--- a/app/src/main/res/drawable/bg_toolbar_glass.xml
+++ b/app/src/main/res/drawable/bg_toolbar_glass.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <solid android:color="#CC1D1A2F" />
+    <solid android:color="#CC0E071D" />
     <corners android:bottomLeftRadius="28dp"
         android:bottomRightRadius="28dp" />
     <stroke

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -12,7 +12,7 @@
         style="@style/AppToolbar"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:title="@string/app_name"
+        app:title=""
         app:titleCentered="true"
         app:navigationIconTint="@color/md_theme_light_primary"
         app:layout_constraintTop_toTopOf="parent"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Dreamy lavender & seafoam palette -->
-    <color name="md_theme_light_primary">#C7AFFF</color>
-    <color name="md_theme_light_onPrimary">#251A3C</color>
-    <color name="md_theme_light_primaryContainer">#3B2C55</color>
-    <color name="md_theme_light_onPrimaryContainer">#F4EDFF</color>
+    <!-- Luxe noir & amethyst palette -->
+    <color name="md_theme_light_primary">#A678FF</color>
+    <color name="md_theme_light_onPrimary">#0F041F</color>
+    <color name="md_theme_light_primaryContainer">#2F1452</color>
+    <color name="md_theme_light_onPrimaryContainer">#F4ECFF</color>
 
-    <color name="md_theme_light_secondary">#89D8C2</color>
-    <color name="md_theme_light_onSecondary">#08241E</color>
-    <color name="md_theme_light_secondaryContainer">#274F45</color>
-    <color name="md_theme_light_onSecondaryContainer">#DAF7EF</color>
+    <color name="md_theme_light_secondary">#7A63FF</color>
+    <color name="md_theme_light_onSecondary">#090315</color>
+    <color name="md_theme_light_secondaryContainer">#251B3E</color>
+    <color name="md_theme_light_onSecondaryContainer">#E4DDFF</color>
 
-    <color name="md_theme_light_tertiary">#F6BCD5</color>
-    <color name="md_theme_light_surface">#141223</color>
-    <color name="md_theme_light_surfaceVariant">#1C1A2C</color>
-    <color name="md_theme_light_surfaceContainer">#201E31</color>
-    <color name="md_theme_light_onSurface">#F6F2FF</color>
-    <color name="md_theme_light_onSurfaceVariant">#CBC6E1</color>
-    <color name="md_theme_light_outline">#3F3A53</color>
-    <color name="md_theme_light_outlineVariant">#2C283D</color>
+    <color name="md_theme_light_tertiary">#C9A5FF</color>
+    <color name="md_theme_light_surface">#05030B</color>
+    <color name="md_theme_light_surfaceVariant">#0D0619</color>
+    <color name="md_theme_light_surfaceContainer">#140C26</color>
+    <color name="md_theme_light_onSurface">#F6F1FF</color>
+    <color name="md_theme_light_onSurfaceVariant">#C5B8E4</color>
+    <color name="md_theme_light_outline">#3F2F5B</color>
+    <color name="md_theme_light_outlineVariant">#271B39</color>
     <color name="md_theme_light_error">#F28B82</color>
     <color name="md_theme_light_warning">#F7C27D</color>
     <color name="md_theme_light_success">#8EE5C2</color>
@@ -26,24 +26,24 @@
     <color name="colorSuccess">#8EE5C2</color>
     <color name="colorWarning">#F7C27D</color>
     <color name="colorError">#F28B82</color>
-    <color name="colorInfo">#8ABFF9</color>
+    <color name="colorInfo">#9FA8FF</color>
 
-    <color name="colorCardStroke">#33C7AFFF</color>
-    <color name="glass_background">#1AE3E1F6</color>
-    <color name="glass_background_elevated">#26E3E1F6</color>
-    <color name="glass_stroke">#40C7AFFF</color>
+    <color name="colorCardStroke">#33A678FF</color>
+    <color name="glass_background">#1AA678FF</color>
+    <color name="glass_background_elevated">#26A678FF</color>
+    <color name="glass_stroke">#40A678FF</color>
 
-    <color name="message_incoming_bg">#2B2539</color>
-    <color name="message_incoming_stroke">#4A4362</color>
-    <color name="message_outgoing_start">#BFA8FF</color>
-    <color name="message_outgoing_end">#9F8BEB</color>
+    <color name="message_incoming_bg">#181026</color>
+    <color name="message_incoming_stroke">#30214A</color>
+    <color name="message_outgoing_start">#B88BFF</color>
+    <color name="message_outgoing_end">#8F5CFF</color>
 
-    <color name="text_primary">#F6F2FF</color>
-    <color name="text_secondary">#CBC6E1</color>
-    <color name="text_muted">#A19DBD</color>
+    <color name="text_primary">#F6F1FF</color>
+    <color name="text_secondary">#C5B8E4</color>
+    <color name="text_muted">#9285B5</color>
 
-    <color name="bottom_nav_active">#C7AFFF</color>
-    <color name="bottom_nav_inactive">#7E799B</color>
+    <color name="bottom_nav_active">#A678FF</color>
+    <color name="bottom_nav_inactive">#5C5476</color>
 
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>


### PR DESCRIPTION
## Summary
- restyle the shared color resources around a black and amethyst palette for a more luxurious tone
- refresh gradient, glass, and halo drawables plus the main toolbar to align with the new theme
- streamline fragment toolbar setup by reusing the activity cast helper

## Testing
- ./gradlew lintDebug *(fails: Android SDK not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4850d04348320b6071b73715be6dd