### PR TITLE
Revamp chat list UI with green noir palette

### DIFF
--- a/app/src/main/java/com/example/texty/ui/ChatListFragment.kt
+++ b/app/src/main/java/com/example/texty/ui/ChatListFragment.kt
@@ -2,10 +2,11 @@ package com.example.texty.ui
 
 import android.content.Intent
 import android.os.Bundle
-import android.view.*
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
 import android.widget.CheckBox
 import android.widget.TextView
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.widget.addTextChangedListener
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -20,7 +21,7 @@ import com.example.texty.repository.ChatRoomRepository
 import com.example.texty.repository.UserRepository
 import com.example.texty.util.AppLogger
 import com.example.texty.util.ErrorLogger
-import com.google.android.material.appbar.MaterialToolbar
+import com.google.android.material.button.MaterialButton
 import com.google.android.material.progressindicator.CircularProgressIndicator
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.textfield.TextInputEditText
@@ -50,7 +51,6 @@ class ChatListFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        setHasOptionsMenu(true)
         return inflater.inflate(R.layout.fragment_chat_list, container, false)
     }
 
@@ -58,9 +58,6 @@ class ChatListFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         val currentUser = Firebase.auth.currentUser ?: return // 👈 evita crash si ya está null
-        val toolbar = view.findViewById<MaterialToolbar>(R.id.topAppBar)
-        val activity = requireActivity() as AppCompatActivity
-        activity.setSupportActionBar(toolbar)
 
         adapter = ChatListAdapter { room ->
             if (room.isGroup) {
@@ -97,6 +94,18 @@ class ChatListFragment : Fragment() {
         searchInput = view.findViewById(R.id.editSearch)
         searchInput.addTextChangedListener { text ->
             filterRooms(text?.toString() ?: "")
+        }
+
+        view.findViewById<MaterialButton>(R.id.buttonCreateGroup).setOnClickListener {
+            openCreateGroupDialog()
+        }
+
+        view.findViewById<MaterialButton>(R.id.buttonShareLogs).setOnClickListener {
+            AppLogger.shareLogs(requireContext())
+        }
+
+        view.findViewById<MaterialButton>(R.id.buttonLogout).setOnClickListener {
+            performLogout()
         }
 
         viewModel.loading.observe(viewLifecycleOwner) { isLoading ->
@@ -223,33 +232,6 @@ class ChatListFragment : Fragment() {
         }
     }
 
-
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        inflater.inflate(R.menu.menu_chat_list, menu)
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return when (item.itemId) {
-            R.id.action_create_group -> {
-                openCreateGroupDialog()
-                true
-            }
-            R.id.action_logout -> {
-                FirebaseAuth.getInstance().signOut()
-                // 👇 redirigir inmediatamente para que el fragmento no intente acceder al usuario null
-                val intent = Intent(requireContext(), LoginActivity::class.java)
-                intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-                startActivity(intent)
-                requireActivity().finish()
-                true
-            }
-            R.id.action_share_logs -> {
-                AppLogger.shareLogs(requireContext())
-                true
-            }
-            else -> super.onOptionsItemSelected(item)
-        }
-    }
 
     private fun filterRooms(query: String) {
         if (query.isBlank()) {
@@ -396,6 +378,15 @@ class ChatListFragment : Fragment() {
 
     private class FriendVH(view: View) : RecyclerView.ViewHolder(view) {
         val checkBox: CheckBox = view.findViewById(R.id.checkBoxFriend)
+    }
+
+    private fun performLogout() {
+        FirebaseAuth.getInstance().signOut()
+        val intent = Intent(requireContext(), LoginActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        }
+        startActivity(intent)
+        requireActivity().finish()
     }
 }
 

--- a/app/src/main/res/drawable/bg_app_gradient.xml
+++ b/app/src/main/res/drawable/bg_app_gradient.xml
@@ -2,8 +2,8 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <gradient
-        android:startColor="#05030B"
-        android:endColor="#170A32"
+        android:startColor="#050505"
+        android:endColor="#0B2C1D"
         android:type="linear"
         android:angle="90" />
 </shape>

--- a/app/src/main/res/drawable/bg_chat_list.xml
+++ b/app/src/main/res/drawable/bg_chat_list.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <gradient
+        android:startColor="@color/chat_background_top"
+        android:endColor="@color/chat_background_bottom"
+        android:angle="270" />
+    <corners android:radius="0dp" />
+</shape>

--- a/app/src/main/res/drawable/bg_list_surface.xml
+++ b/app/src/main/res/drawable/bg_list_surface.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/chat_surface" />
+    <corners android:radius="28dp" />
+    <padding
+        android:left="0dp"
+        android:top="0dp"
+        android:right="0dp"
+        android:bottom="0dp" />
+</shape>

--- a/app/src/main/res/drawable/bg_toolbar_glass.xml
+++ b/app/src/main/res/drawable/bg_toolbar_glass.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <solid android:color="#CC0E071D" />
+    <solid android:color="#CC0C2B1B" />
     <corners android:bottomLeftRadius="28dp"
         android:bottomRightRadius="28dp" />
     <stroke

--- a/app/src/main/res/layout/fragment_chat_list.xml
+++ b/app/src/main/res/layout/fragment_chat_list.xml
@@ -4,21 +4,103 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:animateLayoutChanges="true"
-    android:background="@android:color/transparent"
+    android:background="@drawable/bg_chat_list"
     android:fitsSystemWindows="true">
 
-    <com.google.android.material.appbar.MaterialToolbar
-        android:id="@+id/topAppBar"
-        style="@style/AppToolbar"
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/headerContainer"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:paddingStart="24dp"
-        android:paddingEnd="24dp"
-        app:title="@string/chats_title"
-        app:titleCentered="true"
-        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginStart="24dp"
+        android:layout_marginTop="32dp"
+        android:layout_marginEnd="24dp"
+        app:cardBackgroundColor="@color/chat_surface_variant"
+        app:cardCornerRadius="28dp"
+        app:cardElevation="0dp"
+        app:strokeColor="@color/chat_surface_overlay"
+        app:strokeWidth="1dp"
+        app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingStart="24dp"
+            android:paddingTop="20dp"
+            android:paddingEnd="16dp"
+            android:paddingBottom="20dp">
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/textTitle"
+                style="@style/TextAppearance.Texty.Headline"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/chats_title"
+                android:textColor="@color/chat_accent"
+                android:textSize="24sp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/textSubtitle"
+                style="@style/TextAppearance.Texty.Body"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:layout_marginEnd="8dp"
+                android:text="@string/chats_subtitle"
+                android:textColor="@color/text_secondary"
+                app:layout_constraintEnd_toStartOf="@id/actionsContainer"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/textTitle"
+                app:layout_constraintBottom_toBottomOf="parent" />
+
+            <LinearLayout
+                android:id="@+id/actionsContainer"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/buttonCreateGroup"
+                    style="@style/Widget.Texty.IconButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    android:contentDescription="@string/create_group"
+                    app:icon="@drawable/baseline_add_reaction_24"
+                    app:iconTint="@color/chat_accent" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/buttonShareLogs"
+                    style="@style/Widget.Texty.IconButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    android:contentDescription="@string/share_logs"
+                    app:icon="@android:drawable/ic_menu_share"
+                    app:iconTint="@color/chat_accent" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/buttonLogout"
+                    style="@style/Widget.Texty.IconButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    android:contentDescription="@string/logout"
+                    app:icon="@drawable/ic_logout"
+                    app:iconTint="@color/chat_accent" />
+
+            </LinearLayout>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </com.google.android.material.card.MaterialCardView>
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/searchLayout"
@@ -29,10 +111,15 @@
         android:layout_marginTop="20dp"
         android:layout_marginEnd="24dp"
         android:layout_marginBottom="4dp"
+        app:boxBackgroundColor="@color/chat_surface"
+        app:boxStrokeColor="@color/chat_accent_dim"
+        app:boxStrokeWidth="1dp"
+        app:boxStrokeWidthFocused="2dp"
+        app:startIconTint="@color/chat_accent"
         app:startIconDrawable="@drawable/ic_search"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/topAppBar">
+        app:layout_constraintTop_toBottomOf="@id/headerContainer">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/editSearch"
@@ -40,6 +127,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="@string/search_hint"
+            android:textColor="@color/text_primary"
+            android:textColorHint="@color/chat_hint_text"
             android:imeOptions="actionSearch"
             android:inputType="text" />
     </com.google.android.material.textfield.TextInputLayout>
@@ -53,10 +142,10 @@
         android:layout_marginEnd="24dp"
         android:layout_marginBottom="24dp"
         android:animateLayoutChanges="true"
-        app:cardBackgroundColor="@color/glass_background_elevated"
-        app:cardCornerRadius="32dp"
+        app:cardBackgroundColor="@color/chat_surface"
+        app:cardCornerRadius="36dp"
         app:cardElevation="0dp"
-        app:strokeColor="@color/glass_stroke"
+        app:strokeColor="@color/chat_surface_overlay"
         app:strokeWidth="1dp"
         app:layout_constraintTop_toBottomOf="@id/searchLayout"
         app:layout_constraintStart_toStartOf="parent"
@@ -68,7 +157,8 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:animateLayoutChanges="true"
-            android:padding="8dp">
+            android:background="@drawable/bg_list_surface"
+            android:padding="12dp">
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/recyclerChats"

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="md_theme_light_primary">#C7AFFF</color>
-    <color name="md_theme_light_onPrimary">#251A3C</color>
-    <color name="md_theme_light_primaryContainer">#3B2C55</color>
-    <color name="md_theme_light_onPrimaryContainer">#F4EDFF</color>
+    <color name="md_theme_light_primary">#1ED760</color>
+    <color name="md_theme_light_onPrimary">#00180D</color>
+    <color name="md_theme_light_primaryContainer">#12492B</color>
+    <color name="md_theme_light_onPrimaryContainer">#B9F7D5</color>
 
-    <color name="md_theme_light_secondary">#89D8C2</color>
-    <color name="md_theme_light_onSecondary">#08241E</color>
-    <color name="md_theme_light_secondaryContainer">#274F45</color>
-    <color name="md_theme_light_onSecondaryContainer">#DAF7EF</color>
+    <color name="md_theme_light_secondary">#17A452</color>
+    <color name="md_theme_light_onSecondary">#00160B</color>
+    <color name="md_theme_light_secondaryContainer">#113921</color>
+    <color name="md_theme_light_onSecondaryContainer">#A2F2BF</color>
 
-    <color name="md_theme_light_tertiary">#F6BCD5</color>
-    <color name="md_theme_light_surface">#141223</color>
-    <color name="md_theme_light_surfaceVariant">#1C1A2C</color>
-    <color name="md_theme_light_surfaceContainer">#201E31</color>
-    <color name="md_theme_light_onSurface">#F6F2FF</color>
-    <color name="md_theme_light_onSurfaceVariant">#CBC6E1</color>
-    <color name="md_theme_light_outline">#3F3A53</color>
-    <color name="md_theme_light_outlineVariant">#2C283D</color>
+    <color name="md_theme_light_tertiary">#15E072</color>
+    <color name="md_theme_light_surface">#080808</color>
+    <color name="md_theme_light_surfaceVariant">#10271C</color>
+    <color name="md_theme_light_surfaceContainer">#132F21</color>
+    <color name="md_theme_light_onSurface">#E8FFF4</color>
+    <color name="md_theme_light_onSurfaceVariant">#98D1B0</color>
+    <color name="md_theme_light_outline">#1F6F3F</color>
+    <color name="md_theme_light_outlineVariant">#114427</color>
     <color name="md_theme_light_error">#F28B82</color>
     <color name="md_theme_light_warning">#F7C27D</color>
     <color name="md_theme_light_success">#8EE5C2</color>
@@ -25,7 +25,7 @@
     <color name="colorSuccess">#8EE5C2</color>
     <color name="colorWarning">#F7C27D</color>
     <color name="colorError">#F28B82</color>
-    <color name="colorInfo">#8ABFF9</color>
+    <color name="colorInfo">#7FD9A9</color>
 
-    <color name="colorCardStroke">#2C283D</color>
+    <color name="colorCardStroke">#331ED760</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Luxe noir & amethyst palette -->
-    <color name="md_theme_light_primary">#A678FF</color>
-    <color name="md_theme_light_onPrimary">#0F041F</color>
-    <color name="md_theme_light_primaryContainer">#2F1452</color>
-    <color name="md_theme_light_onPrimaryContainer">#F4ECFF</color>
+    <color name="md_theme_light_primary">#1ED760</color>
+    <color name="md_theme_light_onPrimary">#00180D</color>
+    <color name="md_theme_light_primaryContainer">#0C2B1B</color>
+    <color name="md_theme_light_onPrimaryContainer">#CBFFE4</color>
 
-    <color name="md_theme_light_secondary">#7A63FF</color>
-    <color name="md_theme_light_onSecondary">#090315</color>
-    <color name="md_theme_light_secondaryContainer">#251B3E</color>
-    <color name="md_theme_light_onSecondaryContainer">#E4DDFF</color>
+    <color name="md_theme_light_secondary">#17A452</color>
+    <color name="md_theme_light_onSecondary">#00170B</color>
+    <color name="md_theme_light_secondaryContainer">#0F3C23</color>
+    <color name="md_theme_light_onSecondaryContainer">#B0F7C9</color>
 
-    <color name="md_theme_light_tertiary">#C9A5FF</color>
-    <color name="md_theme_light_surface">#05030B</color>
-    <color name="md_theme_light_surfaceVariant">#0D0619</color>
-    <color name="md_theme_light_surfaceContainer">#140C26</color>
-    <color name="md_theme_light_onSurface">#F6F1FF</color>
-    <color name="md_theme_light_onSurfaceVariant">#C5B8E4</color>
-    <color name="md_theme_light_outline">#3F2F5B</color>
-    <color name="md_theme_light_outlineVariant">#271B39</color>
+    <color name="md_theme_light_tertiary">#18E27A</color>
+    <color name="md_theme_light_surface">#050505</color>
+    <color name="md_theme_light_surfaceVariant">#0B1F16</color>
+    <color name="md_theme_light_surfaceContainer">#0F241A</color>
+    <color name="md_theme_light_onSurface">#F1FFF8</color>
+    <color name="md_theme_light_onSurfaceVariant">#A7D7BA</color>
+    <color name="md_theme_light_outline">#1F6F3F</color>
+    <color name="md_theme_light_outlineVariant">#114427</color>
     <color name="md_theme_light_error">#F28B82</color>
     <color name="md_theme_light_warning">#F7C27D</color>
     <color name="md_theme_light_success">#8EE5C2</color>
@@ -28,22 +28,31 @@
     <color name="colorError">#F28B82</color>
     <color name="colorInfo">#9FA8FF</color>
 
-    <color name="colorCardStroke">#33A678FF</color>
-    <color name="glass_background">#1AA678FF</color>
-    <color name="glass_background_elevated">#26A678FF</color>
-    <color name="glass_stroke">#40A678FF</color>
+    <color name="colorCardStroke">#331ED760</color>
+    <color name="glass_background">#1A1B2922</color>
+    <color name="glass_background_elevated">#26202725</color>
+    <color name="glass_stroke">#401ED760</color>
 
-    <color name="message_incoming_bg">#181026</color>
-    <color name="message_incoming_stroke">#30214A</color>
-    <color name="message_outgoing_start">#B88BFF</color>
-    <color name="message_outgoing_end">#8F5CFF</color>
+    <color name="message_incoming_bg">#111C16</color>
+    <color name="message_incoming_stroke">#1F6F3F</color>
+    <color name="message_outgoing_start">#1ED760</color>
+    <color name="message_outgoing_end">#109B44</color>
 
-    <color name="text_primary">#F6F1FF</color>
-    <color name="text_secondary">#C5B8E4</color>
-    <color name="text_muted">#9285B5</color>
+    <color name="text_primary">#F1FFF8</color>
+    <color name="text_secondary">#B0F7C9</color>
+    <color name="text_muted">#6FA585</color>
 
-    <color name="bottom_nav_active">#A678FF</color>
-    <color name="bottom_nav_inactive">#5C5476</color>
+    <color name="bottom_nav_active">#1ED760</color>
+    <color name="bottom_nav_inactive">#335746</color>
+
+    <color name="chat_background_top">#FF050505</color>
+    <color name="chat_background_bottom">#FF0B2C1D</color>
+    <color name="chat_surface">#FF101010</color>
+    <color name="chat_surface_variant">#FF13231A</color>
+    <color name="chat_surface_overlay">#661ED760</color>
+    <color name="chat_accent">#FF1ED760</color>
+    <color name="chat_accent_dim">#991ED760</color>
+    <color name="chat_hint_text">#99F1FFF8</color>
 
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,11 +16,13 @@
     <string name="display_name">Nombre</string>
     <string name="profile_photo">Foto de perfil</string>
     <string name="chats_title">Chats</string>
+    <string name="chats_subtitle">Conecta y conversa con estilo</string>
     <string name="error_invalid_user">Usuario no registrado</string>
     <string name="error_invalid_credentials">Credenciales incorrectas</string>
     <string name="error_network">Error de red</string>
     <string name="no_chats_placeholder">No tienes chats aún</string>
     <string name="share_logs">Compartir logs</string>
+    <string name="create_group">Nuevo grupo</string>
     <string name="new_chat">Nuevo chat</string>
     <string name="error_group_name_required">Escribe un nombre para el grupo</string>
     <string name="error_group_members_required">Selecciona al menos un miembro</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -115,6 +115,18 @@
         <item name="android:textSize">16sp</item>
     </style>
 
+    <style name="Widget.Texty.IconButton" parent="Widget.Material3.Button.IconButton">
+        <item name="android:minWidth">0dp</item>
+        <item name="android:minHeight">0dp</item>
+        <item name="android:paddingLeft">0dp</item>
+        <item name="android:paddingRight">0dp</item>
+        <item name="android:paddingTop">0dp</item>
+        <item name="android:paddingBottom">0dp</item>
+        <item name="backgroundTint">@color/chat_surface</item>
+        <item name="iconTint">@color/chat_accent</item>
+        <item name="rippleColor">@color/chat_surface_overlay</item>
+    </style>
+
     <style name="TextAppearance.Texty.Headline" parent="TextAppearance.Material3.TitleLarge">
         <item name="android:textColor">@color/text_primary</item>
         <item name="android:fontFamily">sans-serif-medium</item>


### PR DESCRIPTION
## Summary
- replace the chat list toolbar with a custom header that hosts quick actions and fits the new layout
- modernize the chat list card, search field, and background with a black and green aesthetic
- update shared color resources, gradients, and icon button styling to match the refreshed theme across light and night modes

## Testing
- ./gradlew lint *(fails: Android SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4880431308320af7f71fca57f4610