### PR TITLE
Escape ampersands in font provider queries

### DIFF
--- a/app/src/main/res/font/inter_medium.xml
+++ b/app/src/main/res/font/inter_medium.xml
@@ -2,5 +2,5 @@
 <font-family xmlns:android="http://schemas.android.com/apk/res/android"
     android:fontProviderAuthority="com.google.android.gms.fonts"
     android:fontProviderPackage="com.google.android.gms"
-    android:fontProviderQuery="name=Inter&weight=500"
+    android:fontProviderQuery="name=Inter&amp;weight=500"
     android:fontProviderCerts="@array/com_google_android_gms_fonts_certs" />

--- a/app/src/main/res/font/inter_semibold.xml
+++ b/app/src/main/res/font/inter_semibold.xml
@@ -2,5 +2,5 @@
 <font-family xmlns:android="http://schemas.android.com/apk/res/android"
     android:fontProviderAuthority="com.google.android.gms.fonts"
     android:fontProviderPackage="com.google.android.gms"
-    android:fontProviderQuery="name=Inter&weight=600"
+    android:fontProviderQuery="name=Inter&amp;weight=600"
     android:fontProviderCerts="@array/com_google_android_gms_fonts_certs" />


### PR DESCRIPTION
## Summary
- escape the ampersand in the Inter medium font provider query to keep the XML valid
- do the same for the Inter semibold font resource

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4930e88008320b352a45051473b6a