### PR TITLE
Fix radial gradient configuration for chat background

### DIFF
--- a/app/src/main/res/drawable/bg_chat_aurora.xml
+++ b/app/src/main/res/drawable/bg_chat_aurora.xml
@@ -15,6 +15,7 @@
                 android:type="radial"
                 android:centerX="30%"
                 android:centerY="20%"
+                android:gradientRadius="260dp"
                 android:startColor="#335AB8FF"
                 android:endColor="#00336699" />
         </shape>
@@ -26,6 +27,7 @@
                 android:type="radial"
                 android:centerX="80%"
                 android:centerY="70%"
+                android:gradientRadius="210dp"
                 android:startColor="#33F47C4C"
                 android:endColor="#00231F1C" />
         </shape>


### PR DESCRIPTION
## Summary
- add the missing gradientRadius attribute to the radial layers of the chat background drawable so the layout can inflate correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e49493f2e88320895db077db64d53b