### PR TITLE
Fix sender attribution for incoming notifications

### DIFF
--- a/app/src/main/java/com/example/texty/MessagingService.kt
+++ b/app/src/main/java/com/example/texty/MessagingService.kt
@@ -36,10 +36,14 @@ class MessagingService : FirebaseMessagingService() {
     val roomId = data["roomId"] ?: data["chatId"]
     val messageId = data["messageId"]
 
-    val title = data["senderName"]
-      ?: message.notification?.title
+    val senderName = data["senderName"]?.takeIf { it.isNotBlank() }
+    val fallbackTitle = message.notification?.title?.takeIf { !it.isNullOrBlank() }
+    val title = senderName
+      ?: data["senderId"]?.takeIf { it.isNotBlank() }
+      ?: fallbackTitle
       ?: getString(R.string.notification_generic_title)
-    val defaultBody = getString(R.string.notification_generic_body)
+    val defaultBody = data["body"]?.takeIf { it.isNotBlank() }
+      ?: getString(R.string.notification_generic_body)
 
     // Si no podemos publicar notificaciones, salimos silenciosamente
     if (!canPostNotifications()) return

--- a/functions/index.js
+++ b/functions/index.js
@@ -12,6 +12,47 @@ function chunk(arr, n = 500) {
     return out;
 }
 
+/**
+ * Obtiene un nombre visible para el remitente.
+ * Primero intenta usar el nombre incluido en el mensaje y, si está vacío,
+ * consulta el perfil del usuario en Firestore para reutilizar su displayName.
+ */
+async function resolveSenderName(msg) {
+    const raw = typeof msg?.senderName === 'string' ? msg.senderName.trim() : '';
+    if (raw) return raw;
+
+    const senderId = typeof msg?.senderId === 'string' ? msg.senderId.trim() : '';
+    if (!senderId) return '';
+
+    try {
+        const snap = await admin.firestore().collection('users').doc(senderId).get();
+        const profileName = typeof snap.get('displayName') === 'string'
+            ? snap.get('displayName').trim()
+            : '';
+        if (profileName) return profileName;
+    } catch (error) {
+        console.warn('resolveSenderName error', {
+            senderId,
+            error: error?.message || error,
+        });
+    }
+
+    return senderId;
+}
+
+/** Define un cuerpo simple dependiendo del tipo de mensaje recibido. */
+function resolveNotificationBody(msg) {
+    const preview = typeof msg?.preview === 'string' ? msg.preview.trim() : '';
+    if (preview) return preview;
+
+    const messageType = typeof msg?.messageType === 'string' ? msg.messageType : '';
+    if (messageType.startsWith('media/')) {
+        if (messageType === 'media/image') return 'Te envió una imagen';
+        return 'Te envió un archivo adjunto';
+    }
+    return 'Tienes un mensaje nuevo';
+}
+
 /** Lee participantIds del room. Si no existe, intenta deducirlos del roomId o del mensaje. */
 async function getParticipants(roomId, msg) {
     const ref = admin.firestore().collection('rooms').doc(roomId);
@@ -71,6 +112,8 @@ exports.sendMessageNotification = functions.firestore
         const roomId = context.params.roomId;
         const messageId = context.params.messageId;
 
+        const senderName = await resolveSenderName(msg);
+
         // 1) Participantes y destinatarios (excluye remitente)
         const participants = await getParticipants(roomId, msg);
         const recipients = participants.filter((uid) => uid && uid !== msg.senderId);
@@ -87,8 +130,8 @@ exports.sendMessageNotification = functions.firestore
         if (!tokens.length) return null;
 
         // 3) Payload
-        const title = msg.senderName || 'Nuevo mensaje';
-        const body = 'Tienes un mensaje nuevo';
+        const title = senderName || 'Nuevo mensaje';
+        const body = resolveNotificationBody(msg);
 
         const common = {
             notification: { title, body },
@@ -97,7 +140,7 @@ exports.sendMessageNotification = functions.firestore
                 roomId: roomId || '',
                 messageId: messageId || '',
                 senderId: msg.senderId || '',
-                senderName: msg.senderName || '',
+                senderName: senderName || '',
                 body,
             },
             android: { priority: 'high' },


### PR DESCRIPTION
## Summary
- ensure the Android messaging service falls back to sender id and provided body text when the notification payload lacks a name
- resolve the sender display name on the Cloud Function using the Firestore profile and provide a context-aware notification body

## Testing
- `./gradlew testDebugUnitTest` *(fails: Android SDK not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4968d684c832084d941cf73206fce