### PR TITLE
Rename app to Texty

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">LunaChat</string>
+    <string name="app_name">Texty</string>
     <string name="invalid_email">Email inválido</string>
     <string name="invalid_password">La contraseña debe tener al menos 6 caracteres</string>
     <string name="error_generic">Error</string>


### PR DESCRIPTION
## Summary
- update the localized application label to "Texty"

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4a0caffb483209d498743e176a787