### PR TITLE
Fix online presence status updates

### DIFF
--- a/app/src/main/java/com/example/texty/util/OnlineStatusTracker.kt
+++ b/app/src/main/java/com/example/texty/util/OnlineStatusTracker.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.SetOptions
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 
@@ -71,15 +72,18 @@ object OnlineStatusTracker : DefaultLifecycleObserver, FirebaseAuth.AuthStateLis
         if (lastReportedStatus == desiredStatus) return
 
         setOnlineStatus(uid, desiredStatus)
-        lastReportedStatus = desiredStatus
     }
 
     private fun setOnlineStatus(uid: String, online: Boolean) {
         Firebase.firestore.collection("users")
             .document(uid)
-            .update("isOnline", online)
+            .set(mapOf("isOnline" to online), SetOptions.merge())
+            .addOnSuccessListener {
+                lastReportedStatus = online
+            }
             .addOnFailureListener { e ->
                 Log.w(TAG, "No se pudo actualizar el estado en línea para $uid", e)
+                lastReportedStatus = null
             }
     }
 }


### PR DESCRIPTION
## Summary
- update the online status tracker to merge presence updates into the user document instead of relying on update
- only mark the last reported status after a successful write and reset it on failure so new attempts can be made

## Testing
- not run (Android instrumentation tests are not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e5e7a2012c8320a11b0a64bef256a6