### PR TITLE
Adjust online status indicator color

### DIFF
--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -20,9 +20,9 @@
     <color name="md_theme_light_outlineVariant">#1C293A</color>
     <color name="md_theme_light_error">#FF7A7A</color>
     <color name="md_theme_light_warning">#F2B872</color>
-    <color name="md_theme_light_success">#7CD8A7</color>
+    <color name="md_theme_light_success">#37D883</color>
 
-    <color name="colorSuccess">#7CD8A7</color>
+    <color name="colorSuccess">#37D883</color>
     <color name="colorWarning">#F2B872</color>
     <color name="colorError">#FF7A7A</color>
     <color name="colorInfo">#5AB8FF</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -21,9 +21,9 @@
     <color name="md_theme_light_outlineVariant">#1C293A</color>
     <color name="md_theme_light_error">#FF7A7A</color>
     <color name="md_theme_light_warning">#F2B872</color>
-    <color name="md_theme_light_success">#7CD8A7</color>
+    <color name="md_theme_light_success">#37D883</color>
 
-    <color name="colorSuccess">#7CD8A7</color>
+    <color name="colorSuccess">#37D883</color>
     <color name="colorWarning">#F2B872</color>
     <color name="colorError">#FF7A7A</color>
     <color name="colorInfo">#5AB8FF</color>


### PR DESCRIPTION
## Summary
- update the success palette color to a brighter green so the online indicator is easier to spot

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68e5f023847c8320b61129079d1e7229